### PR TITLE
Hydration Options, configurable intersection obvs, removal of wrapping spans.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elderjs/elderjs",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/partialHydration/__tests__/partialHydration.spec.ts
+++ b/src/partialHydration/__tests__/partialHydration.spec.ts
@@ -10,6 +10,28 @@ test('#partialHydration', async () => {
   ).toEqual(
     `<div class="needs-hydration" data-hydrate-component="DatePicker"  data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options="{ "loading": "lazy" }" />`,
   );
+
+  expect(
+    (
+      await partialHydration.markup({
+        content: '<DatePicker hydrate-client={{ a: "b" }} hydrate-options={{ loading: "eager" }} />',
+      })
+    ).code,
+  ).toEqual(
+    `<div class="needs-hydration" data-hydrate-component="DatePicker"  data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options={JSON.stringify({ loading: "eager" })} />`,
+  );
+
+  expect(
+    (
+      await partialHydration.markup({
+        content:
+          '<DatePicker hydrate-client={{ a: "b" }} hydrate-options={{ loading: "eager", rootMargin: "500px", threshold: 0 }} />',
+      })
+    ).code,
+  ).toEqual(
+    `<div class="needs-hydration" data-hydrate-component="DatePicker"  data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options={JSON.stringify({ loading: "eager", rootMargin: "500px", threshold: 0 })} />`,
+  );
+
   expect(
     (
       await partialHydration.markup({

--- a/src/partialHydration/__tests__/partialHydration.spec.ts
+++ b/src/partialHydration/__tests__/partialHydration.spec.ts
@@ -8,7 +8,7 @@ test('#partialHydration', async () => {
       })
     ).code,
   ).toEqual(
-    `<div class="needs-hydration" data-component="DatePicker"  data-hydrate={JSON.stringify({ a: "b" })} data-options={JSON.stringify({lazy: true})} />`,
+    `<div class="needs-hydration" data-component="DatePicker"  data-hydrate={JSON.stringify({ a: "b" })} data-options="{ "lazy": true }" />`,
   );
   expect(
     (

--- a/src/partialHydration/__tests__/partialHydration.spec.ts
+++ b/src/partialHydration/__tests__/partialHydration.spec.ts
@@ -7,7 +7,9 @@ test('#partialHydration', async () => {
         content: '<DatePicker hydrate-client={{ a: "b" }} />',
       })
     ).code,
-  ).toEqual(`<div class="needs-hydration" data-component="DatePicker"  data-data={JSON.stringify({ a: "b" })} />`);
+  ).toEqual(
+    `<div class="needs-hydration" data-component="DatePicker"  data-hydrate={JSON.stringify({ a: "b" })} data-options={JSON.stringify({lazy: true})} />`,
+  );
   expect(
     (
       await partialHydration.markup({

--- a/src/partialHydration/__tests__/partialHydration.spec.ts
+++ b/src/partialHydration/__tests__/partialHydration.spec.ts
@@ -8,7 +8,7 @@ test('#partialHydration', async () => {
       })
     ).code,
   ).toEqual(
-    `<div class="needs-hydration" data-hydrate-component="DatePicker"  data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options={JSON.stringify({ "loading": "lazy" })} />`,
+    `<div class="needs-hydration" data-hydrate-component="DatePicker" data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options={JSON.stringify({"loading":"lazy"})} />`,
   );
 
   expect(
@@ -18,7 +18,7 @@ test('#partialHydration', async () => {
       })
     ).code,
   ).toEqual(
-    `<div class="needs-hydration" data-hydrate-component="DatePicker"  data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options={JSON.stringify({ loading: "eager" })} />`,
+    `<div class="needs-hydration" data-hydrate-component="DatePicker" data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options={JSON.stringify({ loading: "eager" })} />`,
   );
 
   expect(
@@ -29,7 +29,7 @@ test('#partialHydration', async () => {
       })
     ).code,
   ).toEqual(
-    `<div class="needs-hydration" data-hydrate-component="DatePicker"  data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options={JSON.stringify({ loading: "eager", rootMargin: "500px", threshold: 0 })} />`,
+    `<div class="needs-hydration" data-hydrate-component="DatePicker" data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options={JSON.stringify({ loading: "eager", rootMargin: "500px", threshold: 0 })} />`,
   );
 
   expect(

--- a/src/partialHydration/__tests__/partialHydration.spec.ts
+++ b/src/partialHydration/__tests__/partialHydration.spec.ts
@@ -8,7 +8,7 @@ test('#partialHydration', async () => {
       })
     ).code,
   ).toEqual(
-    `<div class="needs-hydration" data-component="DatePicker"  data-hydrate={JSON.stringify({ a: "b" })} data-options="{ "lazy": true }" />`,
+    `<div class="needs-hydration" data-hydrate-component="DatePicker"  data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options="{ "loading": "lazy" }" />`,
   );
   expect(
     (

--- a/src/partialHydration/__tests__/partialHydration.spec.ts
+++ b/src/partialHydration/__tests__/partialHydration.spec.ts
@@ -8,7 +8,7 @@ test('#partialHydration', async () => {
       })
     ).code,
   ).toEqual(
-    `<div class="needs-hydration" data-hydrate-component="DatePicker"  data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options="{ "loading": "lazy" }" />`,
+    `<div class="needs-hydration" data-hydrate-component="DatePicker"  data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options={JSON.stringify({ \"loading\": \"lazy\" })} />`,
   );
 
   expect(

--- a/src/partialHydration/__tests__/partialHydration.spec.ts
+++ b/src/partialHydration/__tests__/partialHydration.spec.ts
@@ -8,7 +8,7 @@ test('#partialHydration', async () => {
       })
     ).code,
   ).toEqual(
-    `<div class="needs-hydration" data-hydrate-component="DatePicker"  data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options={JSON.stringify({ \"loading\": \"lazy\" })} />`,
+    `<div class="needs-hydration" data-hydrate-component="DatePicker"  data-hydrate-props={JSON.stringify({ a: "b" })} data-hydrate-options={JSON.stringify({ "loading": "lazy" })} />`,
   );
 
   expect(

--- a/src/partialHydration/partialHydration.ts
+++ b/src/partialHydration/partialHydration.ts
@@ -17,7 +17,7 @@ const partialHydration = {
       if (hydrateOptionsResults && hydrateOptionsResults[1] && hydrateOptionsResults[1].length > 0) {
         replacement += ` data-options={JSON.stringify(${hydrateOptionsResults[1]})}`;
       } else {
-        replacement += ` data-options={JSON.stringify({lazy: true})}`;
+        replacement += ` data-options="{ "lazy": true }"`;
       }
       replacement += ` />`;
       input = input.replace(match[0], replacement);

--- a/src/partialHydration/partialHydration.ts
+++ b/src/partialHydration/partialHydration.ts
@@ -16,7 +16,7 @@ const partialHydration = {
       if (hydrateOptionsResults && hydrateOptionsResults[1] && hydrateOptionsResults[1].length > 0) {
         replacement += ` data-hydrate-options={JSON.stringify(${hydrateOptionsResults[1]})}`;
       } else {
-        replacement += ` data-hydrate-options="{ "loading": "lazy" }"`;
+        replacement += ` data-hydrate-options={JSON.stringify({ "loading": "lazy" })}`;
       }
       replacement += ` />`;
       input = input.replace(wholeMatch, replacement);

--- a/src/partialHydration/partialHydration.ts
+++ b/src/partialHydration/partialHydration.ts
@@ -1,28 +1,72 @@
+// const partialHydration = {
+//   markup: async ({ content /* , filename */ }) => {
+//     let input = content;
+//     // Note: this regex only supports self closing components.
+//     // Slots aren't supported for client hydration either.
+//     const matches = content.matchAll(/<([a-zA-Z]+)[^>]+hydrate-client={([^]*?})}[^/>]+\/>/gim);
+
+//     for (const match of matches) {
+//       const [wholeMatch, componentName, componentProps] = match;
+
+//       // check for hydrate options
+//       const re = /hydrate-options={([^]*?})}/gim;
+//       const hydrateOptionsResults = re.exec(match.input);
+
+//       let replacement = `<div class="needs-hydration" data-hydrate-component="${componentName}"  data-hydrate-props={JSON.stringify(${componentProps})}`;
+//       if (hydrateOptionsResults && hydrateOptionsResults[1] && hydrateOptionsResults[1].length > 0) {
+//         replacement += ` data-hydrate-options={JSON.stringify(${hydrateOptionsResults[1]})}`;
+//       } else {
+//         replacement += ` data-hydrate-options={JSON.stringify({ "loading": "lazy" })}`;
+//       }
+//       replacement += ` />`;
+//       input = input.replace(wholeMatch, replacement);
+//     }
+
+//     return { code: input };
+//   },
+// };
+
+const extractHydrateOptions = (htmlString) => {
+  const hydrateOptionsPattern = /hydrate-options={([^]*?})}/gim;
+
+  const optionsMatch = hydrateOptionsPattern.exec(htmlString);
+  if (optionsMatch) {
+    return optionsMatch[1];
+  }
+  return JSON.stringify({
+    loading: 'lazy',
+  });
+};
+
+const createReplacementString = ({ input, componentName, componentProps }) => {
+  const hydrateOptions = extractHydrateOptions(input);
+  const replacementAttrs = {
+    class: '"needs-hydration"',
+    'data-hydrate-component': `"${componentName}"`,
+    'data-hydrate-props': `{JSON.stringify(${componentProps})}`,
+    'data-hydrate-options': `{JSON.stringify(${hydrateOptions})}`,
+  };
+  const replacementAttrsString = Object.entries(replacementAttrs).reduce(
+    (out, [name, value]) => `${out} ${name}=${value}`,
+    '',
+  );
+  return `<div${replacementAttrsString} />`;
+};
+
 const partialHydration = {
   markup: async ({ content /* , filename */ }) => {
-    let input = content;
     // Note: this regex only supports self closing components.
     // Slots aren't supported for client hydration either.
-    const matches = content.matchAll(/<([a-zA-Z]+)[^>]+hydrate-client={([^]*?})}[^/>]+\/>/gim);
+    const hydrateableComponentPattern = /<([a-zA-Z]+)[^>]+hydrate-client={([^]*?})}[^/>]+\/>/gim;
+    const matches = [...content.matchAll(hydrateableComponentPattern)];
 
-    for (const match of matches) {
+    const output = matches.reduce((out, match) => {
       const [wholeMatch, componentName, componentProps] = match;
+      const replacement = createReplacementString({ input: match.input, componentName, componentProps });
+      return out.replace(wholeMatch, replacement);
+    }, content);
 
-      // check for hydrate options
-      const re = /hydrate-options={([^]*?})}/gim;
-      const hydrateOptionsResults = re.exec(match.input);
-
-      let replacement = `<div class="needs-hydration" data-hydrate-component="${componentName}"  data-hydrate-props={JSON.stringify(${componentProps})}`;
-      if (hydrateOptionsResults && hydrateOptionsResults[1] && hydrateOptionsResults[1].length > 0) {
-        replacement += ` data-hydrate-options={JSON.stringify(${hydrateOptionsResults[1]})}`;
-      } else {
-        replacement += ` data-hydrate-options={JSON.stringify({ "loading": "lazy" })}`;
-      }
-      replacement += ` />`;
-      input = input.replace(wholeMatch, replacement);
-    }
-
-    return { code: input };
+    return { code: output };
   },
 };
 

--- a/src/partialHydration/partialHydration.ts
+++ b/src/partialHydration/partialHydration.ts
@@ -6,21 +6,20 @@ const partialHydration = {
     const matches = content.matchAll(/<([a-zA-Z]+)[^>]+hydrate-client={([^]*?})}[^/>]+\/>/gim);
 
     for (const match of matches) {
-      const componentName = match[1];
-      const dataObject = match[2];
+      const [wholeMatch, componentName, componentProps] = match;
 
       // check for hydrate options
       const re = /hydrate-options={([^]*?})}/gim;
       const hydrateOptionsResults = re.exec(match.input);
 
-      let replacement = `<div class="needs-hydration" data-component="${componentName}"  data-hydrate={JSON.stringify(${dataObject})}`;
+      let replacement = `<div class="needs-hydration" data-hydrate-component="${componentName}"  data-hydrate-props={JSON.stringify(${componentProps})}`;
       if (hydrateOptionsResults && hydrateOptionsResults[1] && hydrateOptionsResults[1].length > 0) {
-        replacement += ` data-options={JSON.stringify(${hydrateOptionsResults[1]})}`;
+        replacement += ` data-hydrate-options={JSON.stringify(${hydrateOptionsResults[1]})}`;
       } else {
-        replacement += ` data-options="{ "lazy": true }"`;
+        replacement += ` data-hydrate-options="{ "loading": "lazy" }"`;
       }
       replacement += ` />`;
-      input = input.replace(match[0], replacement);
+      input = input.replace(wholeMatch, replacement);
     }
 
     return { code: input };

--- a/src/utils/IntersectionObserver.ts
+++ b/src/utils/IntersectionObserver.ts
@@ -1,4 +1,4 @@
-export default ({ el, name, loaded, notLoaded, id, rootMargin = 200 }) => {
+export default ({ el, name, loaded, notLoaded, id, rootMargin = '200px', threshold = 0 }) => {
   return `
       window.addEventListener('load', function (event) {
         var observer${id} = new IntersectionObserver(function(entries, observer) {
@@ -18,8 +18,8 @@ export default ({ el, name, loaded, notLoaded, id, rootMargin = 200 }) => {
             }
           }
         }, {
-          rootMargin: '${rootMargin}px',
-          threshold: 0
+          rootMargin: '${rootMargin}',
+          threshold: ${threshold}
         });
         observer${id}.observe(${el});
       });

--- a/src/utils/IntersectionObserver.ts
+++ b/src/utils/IntersectionObserver.ts
@@ -1,11 +1,7 @@
-import getUniqueId from './getUniqueId';
-
-export default ({ el, name, loaded, notLoaded, distancePx = 200 }) => {
-  const uid = getUniqueId();
-  return /* javascript */ `
-
+export default ({ el, name, loaded, notLoaded, id, rootMargin = 200 }) => {
+  return `
       window.addEventListener('load', function (event) {
-        var observer${uid} = new IntersectionObserver(function(entries, observer) {
+        var observer${id} = new IntersectionObserver(function(entries, observer) {
           var objK = Object.keys(entries);
           var objKl = objK.length;
           var objKi = 0;
@@ -22,10 +18,10 @@ export default ({ el, name, loaded, notLoaded, distancePx = 200 }) => {
             }
           }
         }, {
-          rootMargin: '${distancePx}px',
+          rootMargin: '${rootMargin}px',
           threshold: 0
         });
-        observer${uid}.observe(${el});
+        observer${id}.observe(${el});
       });
     `;
 };

--- a/src/utils/Page.ts
+++ b/src/utils/Page.ts
@@ -2,20 +2,13 @@
 import getUniqueId from './getUniqueId';
 import perf from './perf';
 import prepareProcessStack from './prepareProcessStack';
-import { QueryOptions, SettingOptions, ConfigOptions, RequestOptions } from './types';
+import { QueryOptions, Stack, SettingOptions, ConfigOptions, RequestOptions } from './types';
 import { RoutesOptions } from '../routes/types';
 import createReadOnlyProxy from './createReadOnlyProxy';
 
 const buildPage = async (page) => {
   try {
     page.perf.end('initToBuildGap');
-    // stacks
-    page.headStack = [];
-    page.cssStack = [];
-    page.beforeHydrateStack = [];
-    page.hydrateStack = [];
-    page.customJsStack = [];
-    page.footerStack = [];
 
     await page.runHook('request', page);
 
@@ -155,6 +148,18 @@ class Page {
 
   htmlString: string;
 
+  headStack: Stack;
+
+  cssStack: Stack;
+
+  beforeHydrateStack: Stack;
+
+  hydrateStack: Stack;
+
+  customJsStack: Stack;
+
+  footerStack: Stack;
+
   constructor({
     request,
     settings,
@@ -184,6 +189,13 @@ class Page {
     this.routes = routes;
     this.customProps = customProps;
     this.htmlString = '';
+
+    this.headStack = [];
+    this.cssStack = [];
+    this.beforeHydrateStack = [];
+    this.hydrateStack = [];
+    this.customJsStack = [];
+    this.footerStack = [];
 
     this.processStack = prepareProcessStack(this);
 

--- a/src/utils/__tests__/IntersectionObserver.spec.ts
+++ b/src/utils/__tests__/IntersectionObserver.spec.ts
@@ -14,6 +14,7 @@ test('#IntersectionObserver', () => {
       name: 'IntersectionObserver.spec.js',
       loaded: 'console.log("loaded");',
       notLoaded: 'console.log("not loaded");',
+      id: mockedGetUniqueId(),
     }).trim(),
   ).toEqual(`window.addEventListener('load', function (event) {
         var observerSwrzsrVDCd = new IntersectionObserver(function(entries, observer) {

--- a/src/utils/__tests__/__snapshots__/Page.spec.ts.snap
+++ b/src/utils/__tests__/__snapshots__/Page.spec.ts.snap
@@ -26,14 +26,20 @@ Page {
       "type": "build",
     },
   ],
+  "beforeHydrateStack": Array [],
+  "cssStack": Array [],
+  "customJsStack": Array [],
   "customProps": Object {},
   "data": Object {},
   "errors": Array [],
+  "footerStack": Array [],
+  "headStack": Array [],
   "helpers": Object {
     "metersInAMile": 0.00062137119224,
     "permalinks": Object {},
   },
   "htmlString": "",
+  "hydrateStack": Array [],
   "perf": Object {
     "end": [MockFunction] {
       "calls": Array [

--- a/src/utils/__tests__/svelteComponent.spec.ts
+++ b/src/utils/__tests__/svelteComponent.spec.ts
@@ -108,7 +108,7 @@ describe('#svelteComponent', () => {
         source: 'Datepicker',
         string: `
         function initdatepickerSwrzsrVDCd() {
-
+          
     System.import('public/dist/svelte/Datepicker.a1b2c3.js').then(({ default: App }) => {
     new App({ target: document.getElementById('datepicker-SwrzsrVDCd'), hydrate: true, props: {"a":"b"} });
     });

--- a/src/utils/__tests__/svelteComponent.spec.ts
+++ b/src/utils/__tests__/svelteComponent.spec.ts
@@ -1,24 +1,49 @@
-import { mocked } from 'ts-jest/utils';
-import svelteComponent, { getComponentName, replaceSpecialCharacters } from '../svelteComponent';
-import getUniqueId from '../getUniqueId';
+const componentProps = {
+  page: {
+    hydrateStack: [],
+    errors: [],
+    cssStack: [],
+    headStack: [],
 
-jest.mock('../getUniqueId');
-
-const mockedGetUniqueId = mocked(getUniqueId, true);
-mockedGetUniqueId.mockImplementation(() => 'SwrzsrVDCd');
-
-process.cwd = () => 'test';
-
-jest.mock('path', () => ({
-  resolve: (...strings) => strings.join('/').replace('./', ''),
-}));
+    helpers: {
+      permalinks: jest.fn(),
+    },
+    settings: {
+      locations: {
+        public: '/',
+        svelte: {
+          ssrComponents: '___ELDER___/compiled/',
+          clientComponents: 'public/dist/svelte/',
+        },
+      },
+      $$internal: {
+        hashedComponents: {
+          Home: 'Home.a1b2c3',
+          Datepicker: 'Datepicker.a1b2c3',
+        },
+      },
+    },
+  },
+  props: {},
+};
 
 describe('#svelteComponent', () => {
+  beforeAll(() => {
+    jest.mock('../getUniqueId', () => () => 'SwrzsrVDCd');
+    process.cwd = () => 'test';
+
+    jest.mock('path', () => ({
+      resolve: (...strings) => strings.join('/').replace('./', ''),
+    }));
+  });
+
   beforeEach(() => {
     jest.resetModules();
   });
 
   it('getComponentName works', () => {
+    // eslint-disable-next-line global-require
+    const { getComponentName } = require('../svelteComponent');
     expect(getComponentName('Home.svelte')).toEqual('Home');
     expect(getComponentName('Home.js')).toEqual('Home');
     expect(getComponentName('foo/bar/Home.js')).toEqual('Home');
@@ -26,39 +51,11 @@ describe('#svelteComponent', () => {
   });
 
   it('replaceSpecialCharacters works', () => {
+    // eslint-disable-next-line global-require
+    const { replaceSpecialCharacters } = require('../svelteComponent');
     expect(replaceSpecialCharacters('&quot;&lt;&gt;&#39;&quot;\\n\\\\n\\"&amp;')).toEqual('"<>\'"\\n"&');
     expect(replaceSpecialCharacters('abcd 1234 <&""&>')).toEqual('abcd 1234 <&""&>');
   });
-
-  const home = svelteComponent('Home.svelte');
-  const componentProps = {
-    page: {
-      hydrateStack: [],
-      errors: [],
-      cssStack: [],
-      headStack: [],
-
-      helpers: {
-        permalinks: jest.fn(),
-      },
-      settings: {
-        locations: {
-          public: '/',
-          svelte: {
-            ssrComponents: '___ELDER___/compiled/',
-            clientComponents: 'public/dist/svelte/',
-          },
-        },
-        $$internal: {
-          hashedComponents: {
-            Home: 'Home.a1b2c3',
-            Datepicker: 'Datepicker.a1b2c3',
-          },
-        },
-      },
-    },
-    props: {},
-  };
 
   it('svelteComponent works', () => {
     jest.mock(
@@ -72,6 +69,9 @@ describe('#svelteComponent', () => {
       }),
       { virtual: true },
     );
+    // eslint-disable-next-line global-require
+    const svelteComponent = require('../svelteComponent').default;
+    const home = svelteComponent('Home.svelte');
     expect(home(componentProps)).toEqual(`<div class="svelte-home">mock html output</div>`);
   });
 
@@ -99,6 +99,9 @@ describe('#svelteComponent', () => {
       }),
       { virtual: true },
     );
+    // eslint-disable-next-line global-require
+    const svelteComponent = require('../svelteComponent').default;
+    const home = svelteComponent('Home.svelte');
     expect(home(componentProps)).toEqual(
       `<div class="svelte-datepicker"><div class="datepicker" id="datepicker-SwrzsrVDCd"><div>DATEPICKER</div></div></div>`,
     );

--- a/src/utils/__tests__/svelteComponent.spec.ts
+++ b/src/utils/__tests__/svelteComponent.spec.ts
@@ -72,9 +72,7 @@ describe('#svelteComponent', () => {
       }),
       { virtual: true },
     );
-    expect(home(componentProps)).toEqual(
-      `<span class="home-component" id="home-SwrzsrVDCd"><div class="svelte-home">mock html output</div></span>`,
-    );
+    expect(home(componentProps)).toEqual(`<div class="svelte-home">mock html output</div>`);
   });
 
   it('svelteComponent works with partial hydration of subcomponent', () => {
@@ -85,7 +83,7 @@ describe('#svelteComponent', () => {
           head: '<head>',
           css: { code: '<css>' },
           html:
-            '<div class="svelte-datepicker"><div class="needs-hydration" data-component="Datepicker" data-data="{ "a": "b" }"></div></div>',
+            '<div class="svelte-datepicker"><div class="needs-hydration" data-component="Datepicker" data-hydrate="{ "a": "b" }" data-options="{ "lazy": true }"></div></div>',
         }),
       }),
       { virtual: true },
@@ -102,7 +100,7 @@ describe('#svelteComponent', () => {
       { virtual: true },
     );
     expect(home(componentProps)).toEqual(
-      `<span class="home-component" id="home-SwrzsrVDCd"><div class="svelte-datepicker"><span class="datepicker-component" id="datepicker-SwrzsrVDCd"><div>DATEPICKER</div></span></div></span>`,
+      `<div class="svelte-datepicker"><div class="datepicker" id="datepicker-SwrzsrVDCd"><div>DATEPICKER</div></div></div>`,
     );
     expect(componentProps.page.hydrateStack).toEqual([
       {
@@ -110,12 +108,12 @@ describe('#svelteComponent', () => {
         source: 'Datepicker',
         string: `
         function initdatepickerSwrzsrVDCd() {
-          System.import('public/dist/svelte/Datepicker.a1b2c3.js').then(({ default: App }) => {
-            new App({ target: document.getElementById('datepicker-SwrzsrVDCd'), hydrate: true, props: {"a":"b"} });
-          });
+
+    System.import('public/dist/svelte/Datepicker.a1b2c3.js').then(({ default: App }) => {
+    new App({ target: document.getElementById('datepicker-SwrzsrVDCd'), hydrate: true, props: {"a":"b"} });
+    });
         }
         
-
       window.addEventListener('load', function (event) {
         var observerSwrzsrVDCd = new IntersectionObserver(function(entries, observer) {
           var objK = Object.keys(entries);
@@ -145,3 +143,11 @@ describe('#svelteComponent', () => {
     ]);
   });
 });
+
+/** TODO:
+ * hydrate-options={{ lazy: false }} This would cause the component to be hydrate in a blocking manner.
+ * hydrate-options={{ preload: true }} This adds a preload to the head stack as outlined above... could be preloaded without forcing blocking.
+ * hydrate-options={{ preload: true, lazy: false }} This would preload and be blocking.
+ * hydrate-options={{ rootMargin: '500' }} This would adjust the root margin of the intersection observer. Only usable with lazy: true.
+ * hydrate-options={{ inline: true }}  components are display block by default. If this is true, this adds <div style="display:inline;"> to the wrapper.
+ */

--- a/src/utils/__tests__/svelteComponent.spec.ts
+++ b/src/utils/__tests__/svelteComponent.spec.ts
@@ -83,7 +83,7 @@ describe('#svelteComponent', () => {
           head: '<head>',
           css: { code: '<css>' },
           html:
-            '<div class="svelte-datepicker"><div class="needs-hydration" data-component="Datepicker" data-hydrate="{ "a": "b" }" data-options="{ "lazy": true }"></div></div>',
+            '<div class="svelte-datepicker"><div class="needs-hydration" data-hydrate-component="Datepicker" data-hydrate-props="{ "a": "b" }" data-hydrate-options="{ "loading": "lazy" }"></div></div>',
         }),
       }),
       { virtual: true },

--- a/src/utils/svelteComponent.ts
+++ b/src/utils/svelteComponent.ts
@@ -116,8 +116,15 @@ const svelteComponent = (componentName) => ({ page, props, hydrateOptions }: Com
     )} });
     });`;
 
-    // are we lazy loading?
-    if (hydrateOptions.loading === 'lazy') {
+    if (hydrateOptions.loading === 'eager') {
+      // this is eager loaded. Still requires System.js to be defined.
+      page.hydrateStack.push({
+        source: componentName,
+        priority: 50,
+        string: clientJs,
+      });
+    } else {
+      // we're lazy loading
       page.hydrateStack.push({
         source: componentName,
         priority: 50,
@@ -135,13 +142,6 @@ const svelteComponent = (componentName) => ({ page, props, hydrateOptions }: Com
           id,
         })}
       `,
-      });
-    } else if (hydrateOptions.loading === 'eager') {
-      // this is eager loaded. Still requires System.js to be defined.
-      page.hydrateStack.push({
-        source: componentName,
-        priority: 50,
-        string: clientJs,
       });
     }
 

--- a/src/utils/svelteComponent.ts
+++ b/src/utils/svelteComponent.ts
@@ -131,7 +131,8 @@ const svelteComponent = (componentName) => ({ page, props, hydrateOptions }: Com
           name: `${cleanComponentName.toLowerCase()}`,
           loaded: `init${cleanComponentName.toLowerCase()}${id}();`,
           notLoaded: `init${cleanComponentName.toLowerCase()}${id}();`,
-          rootMargin: hydrateOptions.rootMargin || 200,
+          rootMargin: hydrateOptions.rootMargin || '200px',
+          threshold: hydrateOptions.threshold || 0,
           id,
         })}
       `,

--- a/src/utils/svelteComponent.ts
+++ b/src/utils/svelteComponent.ts
@@ -2,7 +2,6 @@ import path from 'path';
 import getUniqueId from './getUniqueId';
 import IntersectionObserver from './IntersectionObserver';
 import { HydrateOptions } from './types';
-import Page from './Page';
 
 export const getComponentName = (str) => {
   let out = str.replace('.svelte', '').replace('.js', '');
@@ -147,7 +146,7 @@ const svelteComponent = (componentName) => ({ page, props, hydrateOptions }: Com
     }
 
     if (hydrateOptions.inline) {
-      return `<div class="${cleanComponentName.toLowerCase()}" id="${cleanComponentName.toLowerCase()}-${id}"  style="display:inline;">${finalHtmlOuput}</div>`;
+      return `<div class="${cleanComponentName.toLowerCase()}" id="${cleanComponentName.toLowerCase()}-${id}" style="display:inline;">${finalHtmlOuput}</div>`;
     }
     return `<div class="${cleanComponentName.toLowerCase()}" id="${cleanComponentName.toLowerCase()}-${id}">${finalHtmlOuput}</div>`;
   } catch (e) {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -115,6 +115,7 @@ export type ExcludesFalse = <T>(x: T | false) => x is T;
 export type HydrateOptions = {
   lazy: boolean;
   preload: boolean;
-  rootMargin: number;
+  rootMargin: string;
+  threshold: number;
   inline: boolean;
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -95,7 +95,6 @@ export type StackItem = {
   source: string;
   string: string;
   priority: number;
-  name: string;
 };
 
 export type PluginOptions = {
@@ -112,3 +111,10 @@ interface Init {
 }
 
 export type ExcludesFalse = <T>(x: T | false) => x is T;
+
+export type HydrateOptions = {
+  lazy: boolean;
+  preload: boolean;
+  rootMargin: number;
+  inline: boolean;
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -118,3 +118,9 @@ export type HydrateOptions = {
   rootMargin: string;
   threshold: number;
 };
+
+export interface ComponentPayload {
+  page: any;
+  props: any;
+  hydrateOptions?: HydrateOptions;
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -113,9 +113,8 @@ interface Init {
 export type ExcludesFalse = <T>(x: T | false) => x is T;
 
 export type HydrateOptions = {
-  lazy: boolean;
+  loading: string;
   preload: boolean;
   rootMargin: string;
   threshold: number;
-  inline: boolean;
 };


### PR DESCRIPTION
Pretty major refactor of how svelteComponent.ts works. 

- [x] added robust regex for supporting the options defined below.
- [x] update svelteComponent.ts to work with these new options. 
- [x] Removal of wrapping `<span>` on unhydrated components.
- [x] On hydrated components use `<div>` instead of `<span>`
- [x] Allow rootMargin to be passed into the intersection observer so this can be configured. 
- [x] Removed the "inline" concept completely as it can be handled by CSS.
- [x] Preload does not work with Systemjs... (Upon further testing it appears to be working.)
- [x] Look at creating a component cache so we aren't requiring if we already have loaded a component in memory.



*TODO*


### Hydrate Options: 

* hydrate-options={{ loading: 'lazy' }} This is the default config, uses intersection observer.
* hydrate-options={{ loading: 'eager' }} This would cause the component to be hydrate in a blocking manner as soon as the js is rendered.
* hydrate-options={{ preload: true }} This adds a preload to the head stack as outlined above... could be preloaded without forcing blocking.
* hydrate-options={{ preload: true, loading: 'eager' }} This would preload and be blocking.
* hydrate-options={{ rootMargin: '500px', threshold: 0 }} This would adjust the root margin of the intersection observer. Only usable with loading: 'lazy'
 

BREAKING CHANGE: 🧨 Changes the component naming structure. Removes wrapping <span> on
non-hydrated components. Changes wrapping <spans> to divs.

✅ Closes: 14, 15, 12