### PR TITLE
Add a quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ The ElderGuide.com team expects to maintain this project until 2023-2024. For a 
 
 The quickest way to get started is to get started with the [Elder.js template](https://github.com/Elderjs/template) using [degit](https://github.com/Rich-Harris/degit):
 
+```sh
+npx degit Elderjs/template elderjs-app
+
+cd $_
+
+npm install # or "yarn"
+
+npm start
+
+open http://localhost:3000
+```
+
 Here is a demo of the template: [https://elderjs.netlify.app/](https://elderjs.netlify.app/)
 
 ## Full documentation here: https://elderguide.com/tech/elderjs/

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The quickest way to get started is to get started with the [Elder.js template](h
 ```sh
 npx degit Elderjs/template elderjs-app
 
-cd $_
+cd
 
 npm install # or "yarn"
 
@@ -77,5 +77,36 @@ open http://localhost:3000
 ```
 
 Here is a demo of the template: [https://elderjs.netlify.app/](https://elderjs.netlify.app/)
+
+### Developing using the Template:
+
+For development, we recommend running two separate terminals. One for the server and the other for rollup.
+
+**Terminal 1: Server**
+
+```bash
+npm run dev:server # `npm start` above starts a server, but doesn't rebuild your Svelte components on change.
+```
+
+**Terminal 2: Rollup**
+
+```bash
+npm run dev:rollup # This rebuilds your svelte components on change.
+```
+
+Once you have these two terminals open, edit a component file in `src`, save it, and reload the page to see your changes.
+
+### To Build/Serve HTML Locally:
+
+```bash
+npm run build
+```
+
+Let the build finish.
+
+```bash
+npx sirv-cli public
+```
+
 
 ## Full documentation here: https://elderguide.com/tech/elderjs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elderjs/elderjs",
-  "version": "1.0.1",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/utils/__tests__/__snapshots__/validations.spec.ts.snap
+++ b/src/utils/__tests__/__snapshots__/validations.spec.ts.snap
@@ -957,7 +957,7 @@ ObjectSchema {
         "max": true,
         "min": true,
       },
-      "_label": "The priority level a hook should run at. Elder.js hooks run here 100 is the highest priority and 1 is the lowest priority.",
+      "_label": "The priority level a hook should run at. The highest priority is 100 and 1 is the lowest priority.",
       "_mutate": undefined,
       "_options": Object {
         "abortEarly": true,


### PR DESCRIPTION
this fixes #47

As described in the issue, line 65 of the README.md file seems to promise that there is a quick start guide.
This PR add just that.