### PR TITLE
fix: prevent plugin init being called for invalid plugin

### DIFF
--- a/src/Elder.ts
+++ b/src/Elder.ts
@@ -137,6 +137,9 @@ class Elder {
         throw new Error(`Plugin ${pluginName} not found in plugins or node_modules folder.`);
       }
 
+      const validatedPlugin = validatePlugin(plugin);
+      if (!validatedPlugin) return;
+
       plugin =
         plugin.init({
           ...plugin,
@@ -144,8 +147,6 @@ class Elder {
           settings: createReadOnlyProxy(this.settings, 'Settings', 'plugin init()'),
         }) || plugin;
 
-      const validatedPlugin = validatePlugin(plugin);
-      if (!validatedPlugin) return;
       plugin = validatedPlugin;
 
       // clean props the plugin shouldn't be able to change between hook... specifically their hooks;

--- a/src/__tests__/Elder.spec.ts
+++ b/src/__tests__/Elder.spec.ts
@@ -120,6 +120,7 @@ describe('#Elder', () => {
     jest.mock('fs-extra', () => ({
       existsSync: () => true,
     }));
+    const pluginInitSpy = jest.fn();
     jest.mock(
       'test/src/plugins/elder-plugin-upload-s3/index.js',
       () => ({
@@ -139,7 +140,7 @@ describe('#Elder', () => {
         config: {},
         name: 'test',
         description: 'test',
-        init: jest.fn(),
+        init: pluginInitSpy,
       }),
       {
         virtual: true,
@@ -149,6 +150,7 @@ describe('#Elder', () => {
     const { Elder } = require('../index');
     const elder = await new Elder({ context: 'server', worker: true });
     // await elder.bootstrap();
+    expect(pluginInitSpy).not.toHaveBeenCalled();
     expect(elder).toEqual({
       bootstrapComplete: Promise.resolve({}),
       markBootstrapComplete: expect.any(Function),


### PR DESCRIPTION
It seems that the init function should not be loaded for a plugin
before it has been validated.

This change introduces a test to validate the desired behaviour
and adjusts the order of operations