### PR TITLE
fix: check for plugin init before calling

### DIFF
--- a/src/Elder.ts
+++ b/src/Elder.ts
@@ -137,7 +137,7 @@ class Elder {
         throw new Error(`Plugin ${pluginName} not found in plugins or node_modules folder.`);
       }
 
-      if (plugin.init) {
+      if (typeof plugin.init === 'function') {
         plugin =
           plugin.init({
             ...plugin,

--- a/src/Elder.ts
+++ b/src/Elder.ts
@@ -137,12 +137,14 @@ class Elder {
         throw new Error(`Plugin ${pluginName} not found in plugins or node_modules folder.`);
       }
 
-      plugin =
-        plugin.init({
-          ...plugin,
-          config: defaultsDeep(pluginConfigFromConfig, plugin.config),
-          settings: createReadOnlyProxy(this.settings, 'Settings', 'plugin init()'),
-        }) || plugin;
+      if (plugin.init) {
+        plugin =
+          plugin.init({
+            ...plugin,
+            config: defaultsDeep(pluginConfigFromConfig, plugin.config),
+            settings: createReadOnlyProxy(this.settings, 'Settings', 'plugin init()'),
+          }) || plugin;
+      }
 
       const validatedPlugin = validatePlugin(plugin);
       if (!validatedPlugin) return;

--- a/src/__tests__/Elder.spec.ts
+++ b/src/__tests__/Elder.spec.ts
@@ -139,7 +139,138 @@ describe('#Elder', () => {
         config: {},
         name: 'test',
         description: 'test',
+        init: jest.fn().mockImplementation((p) => p),
+      }),
+      {
+        virtual: true,
+      },
+    );
+    // eslint-disable-next-line global-require
+    const { Elder } = require('../index');
+    const elder = await new Elder({ context: 'server', worker: true });
+    // await elder.bootstrap();
+    expect(elder).toEqual({
+      bootstrapComplete: Promise.resolve({}),
+      markBootstrapComplete: expect.any(Function),
+      settings: {
+        $$internal: {
+          clientComponents: 'test/public/svelte',
+          ssrComponents: 'test/___ELDER___/compiled',
+          hashedComponents: { File1: 'entryFile1', File2: 'entryFile2' },
+        },
+        build: false,
+        debug: { automagic: true },
+        hooks: { disable: ['randomHook'] },
+        plugins: {
+          'elder-plugin-upload-s3': {
+            dataBucket: 'elderguide.com',
+            deployId: '11111111',
+            htmlBucket: 'elderguide.com',
+          },
+        },
+        server: { prefix: '/dev' },
+        distDir: 'test/public',
+        rootDir: 'test',
+        srcDir: 'test/src',
+        context: 'server',
+        worker: true,
+      },
+    });
+  });
+
+  it('plugin found without init function', async () => {
+    jest.mock('../utils/validations', () => ({
+      validatePlugin: () => false,
+      validateShortcode: (i) => i,
+    }));
+    jest.mock('fs-extra', () => ({
+      existsSync: () => true,
+    }));
+    jest.mock(
+      'test/src/plugins/elder-plugin-upload-s3/index.js',
+      () => ({
+        hooks: [
+          {
+            hook: 'customizeHooks',
+            name: 'test hook',
+            description: 'just for testing',
+            run: jest.fn(),
+            $$meta: {
+              type: 'hooks.js',
+              addedBy: 'validations.spec.ts',
+            },
+          },
+        ],
+        routes: {},
+        config: {},
+        name: 'test',
+        description: 'test',
+      }),
+      {
+        virtual: true,
+      },
+    );
+    // eslint-disable-next-line global-require
+    const { Elder } = require('../index');
+    const elder = await new Elder({ context: 'server', worker: true });
+    // await elder.bootstrap();
+    expect(elder).toEqual({
+      bootstrapComplete: Promise.resolve({}),
+      markBootstrapComplete: expect.any(Function),
+      settings: {
+        $$internal: {
+          clientComponents: 'test/public/svelte',
+          ssrComponents: 'test/___ELDER___/compiled',
+          hashedComponents: { File1: 'entryFile1', File2: 'entryFile2' },
+        },
+        build: false,
+        debug: { automagic: true },
+        hooks: { disable: ['randomHook'] },
+        plugins: {
+          'elder-plugin-upload-s3': {
+            dataBucket: 'elderguide.com',
+            deployId: '11111111',
+            htmlBucket: 'elderguide.com',
+          },
+        },
+        server: { prefix: '/dev' },
+        distDir: 'test/public',
+        rootDir: 'test',
+        srcDir: 'test/src',
+        context: 'server',
+        worker: true,
+      },
+    });
+  });
+
+  it('plugin found with init function which does not correctly return plugin instance', async () => {
+    jest.mock('../utils/validations', () => ({
+      validatePlugin: () => false,
+      validateShortcode: (i) => i,
+    }));
+    jest.mock('fs-extra', () => ({
+      existsSync: () => true,
+    }));
+    jest.mock(
+      'test/src/plugins/elder-plugin-upload-s3/index.js',
+      () => ({
         init: jest.fn(),
+        hooks: [
+          {
+            hook: 'customizeHooks',
+            name: 'test hook',
+            description: 'just for testing',
+            run: jest.fn(),
+            $$meta: {
+              type: 'hooks.js',
+              addedBy: 'validations.spec.ts',
+            },
+          },
+        ],
+        routes: {},
+        config: {},
+        name: 'test',
+        description: 'test',
       }),
       {
         virtual: true,
@@ -297,7 +428,7 @@ describe('#Elder', () => {
         config: {},
         name: 'test',
         description: 'test',
-        init: jest.fn(),
+        init: jest.fn().mockImplementation((p) => p),
       }),
       {
         virtual: true,


### PR DESCRIPTION
According to the [pluginSchema defined here](https://github.com/Elderjs/elderjs/blob/master/src/utils/validations.ts#L129) the init function is not required. However the current implementation will attempt to call it without asserting that it has been defined. 