### PR TITLE
Feat: Add plugins and external css config to Rollup config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elderjs/elderjs",
-  "version": "1.1.2",
+  "version": "1.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/utils/getRollupConfig.ts
+++ b/src/utils/getRollupConfig.ts
@@ -19,6 +19,7 @@ import ssrOutputPath from './ssrOutputPath';
 
 const production = process.env.NODE_ENV === 'production' || !process.env.ROLLUP_WATCH;
 const elderJsDir = path.resolve(process.cwd(), './node_modules/@elderjs/elderjs/');
+
 const babelIE11 = babel({
   extensions: ['.js', '.mjs', '.html', '.svelte'],
   runtimeHelpers: true,
@@ -173,7 +174,6 @@ export default function getRollupConfig(options) {
   );
   const elderConfig = getElderConfig();
   const { $$internal, distDir, srcDir, rootDir, legacy } = elderConfig;
-
   const { ssrComponents, clientComponents } = $$internal;
   const relSrcDir = srcDir.replace(rootDir, '').substr(1);
 

--- a/src/utils/getRollupConfig.ts
+++ b/src/utils/getRollupConfig.ts
@@ -77,6 +77,7 @@ export function createBrowserConfig({
         preferBuiltins: true,
         rootDir: ie11 ? elderJsDir : process.cwd(),
       }),
+      ...plugins,
       commonjs({ sourceMap: !production }),
     ],
   };
@@ -166,18 +167,12 @@ export function createSSRConfig({
 
 export default function getRollupConfig(options) {
   const defaultOptions = getDefaultRollup();
-  const { svelteConfig, replacements, dev } = defaultsDeep(options, defaultOptions);
+  const { svelteConfig, replacements, dev, externalCss, ssrConfigPlugins, browserConfigPlugins } = defaultsDeep(
+    options,
+    defaultOptions,
+  );
   const elderConfig = getElderConfig();
-  const {
-    $$internal,
-    distDir,
-    srcDir,
-    rootDir,
-    legacy,
-    externalCss,
-    ssrConfigPlugins,
-    browserConfigPlugins,
-  } = elderConfig;
+  const { $$internal, distDir, srcDir, rootDir, legacy } = elderConfig;
 
   const { ssrComponents, clientComponents } = $$internal;
   const relSrcDir = srcDir.replace(rootDir, '').substr(1);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -71,6 +71,9 @@ export type SettingsOptions = {
   context?: string;
   worker?: boolean;
   legacy: boolean;
+  externalCss: boolean;
+  browserConfigPlugins?: any[];
+  ssrConfigPlugins?: any[];
 };
 
 export type QueryOptions = {

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -221,11 +221,7 @@ const rollupSchema = yup.object({
     .default([])
     .notRequired()
     .label('A list of rollup plugins to add to the browser config'),
-  ssrConfigPlugins: yup
-    .array()
-    .default([])
-    .notRequired()
-    .label('A list of rollup plugins to add to the ssr config'),
+  ssrConfigPlugins: yup.array().default([]).notRequired().label('A list of rollup plugins to add to the ssr config'),
 });
 
 function getDefaultRollup(): RollupSettings {

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -211,6 +211,21 @@ const rollupSchema = yup.object({
     .default({})
     .notRequired()
     .label('Replaces the key with the value when rolling up templates'),
+  externalCss: yup
+    .boolean()
+    .default(false)
+    .notRequired()
+    .label('With externalCSS set to true, the default CSS handling of ElderJS will be turned off'),
+  browserConfigPlugins: yup
+    .array()
+    .default([])
+    .notRequired()
+    .label('A list of rollup plugins to add to the browser config'),
+  ssrConfigPlugins: yup
+    .array()
+    .default([])
+    .notRequired()
+    .label('A list of rollup plugins to add to the ssr config'),
 });
 
 function getDefaultRollup(): RollupSettings {


### PR DESCRIPTION
## What
Adding the possibility to add plugins to the rollup config. 
Example:
```
module.exports = [
  ...getRollupConfig({
    svelteConfig,
    ssrConfigPlugins: [myCssPlugin()],
    externalCss: true,
  }),
];
```

## Why
If you want other rollup plugins to manipulate the output from svelte or elder, for instance by letting a CSS plugin write all CSS to an external file. The `externalCss: true` turns off the default `rollupPluginHandleCss` plugin. 