### PR TITLE
Suggestion to fix import for external svelte files

### DIFF
--- a/src/rollup/__tests__/__fixtures__/external/node_modules/test-external-svelte-library/src/components/Button.svelte
+++ b/src/rollup/__tests__/__fixtures__/external/node_modules/test-external-svelte-library/src/components/Button.svelte
@@ -1,15 +1,17 @@
 <script>
-    import Icon from "../components/Icon.svelte";
-  </script>
-  
-  <style>
-    .button {
-      padding: 10px 20px;
-      background-color: #f50;
-      color: #fff;
-      font-weight: bold;
-    }
-  </style>
-  
-  <button class="button"><Icon />
-    <slot /></button>
+  import Icon from '../components/Icon.svelte';
+</script>
+
+<button class="button">
+  <Icon />
+  <slot />
+</button>
+
+<style>
+  .button {
+    padding: 10px 20px;
+    background-color: #f50;
+    color: #fff;
+    font-weight: bold;
+  }
+</style>

--- a/src/rollup/__tests__/__fixtures__/external/node_modules/test-external-svelte-library/src/components/Icon.svelte
+++ b/src/rollup/__tests__/__fixtures__/external/node_modules/test-external-svelte-library/src/components/Icon.svelte
@@ -1,11 +1,11 @@
+<div class="icon">*</div>
+
 <style>
-    .icon {
-      background-color: #fff;
-      border-radius: 10px;
-      width: 10px;
-      height: 10px;
-      color: #000;
-    }
-  </style>
-  
-  <div class="icon">*</div>
+  .icon {
+    background-color: #fff;
+    border-radius: 10px;
+    width: 10px;
+    height: 10px;
+    color: #000;
+  }
+</style>

--- a/src/rollup/__tests__/__fixtures__/external/node_modules/test-external-svelte-library/src/components/Unused.svelte
+++ b/src/rollup/__tests__/__fixtures__/external/node_modules/test-external-svelte-library/src/components/Unused.svelte
@@ -1,0 +1,8 @@
+<div class="unused">This component is not used in this project</div>
+
+<style>
+  .unused {
+    margin: 0 1337px;
+    border: 1px solid antiquewhite;
+  }
+</style>

--- a/src/rollup/__tests__/__fixtures__/external/node_modules/test-external-svelte-library/src/index.js
+++ b/src/rollup/__tests__/__fixtures__/external/node_modules/test-external-svelte-library/src/index.js
@@ -1,2 +1,3 @@
 export { default as Button } from './components/Button.svelte'
 export { default as Icon } from './components/Icon.svelte'
+export { default as Unused } from './components/Unused.svelte'

--- a/src/rollup/__tests__/__fixtures__/external/src/components/Component.svelte
+++ b/src/rollup/__tests__/__fixtures__/external/src/components/Component.svelte
@@ -1,11 +1,12 @@
 <script>
-    import { Icon } from 'test-external-svelte-library';
+  import Icon from 'test-external-svelte-library/src/components/Icon.svelte';
 </script>
-<style>
-    .component {
-        background:orange;
-    }
-</style>
 
-<div class="component"></div>
-<Icon></Icon>
+<div class="component" />
+<Icon />
+
+<style>
+  .component {
+    background: orange;
+  }
+</style>

--- a/src/rollup/__tests__/__fixtures__/external/src/layouts/External.svelte
+++ b/src/rollup/__tests__/__fixtures__/external/src/layouts/External.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { Button } from 'test-external-svelte-library';
+    import Button from 'test-external-svelte-library/src/components/Button.svelte';
     import Component from '../components/Component.svelte'
 </script>
 

--- a/src/rollup/__tests__/rollupPlugin.spec.ts
+++ b/src/rollup/__tests__/rollupPlugin.spec.ts
@@ -629,9 +629,7 @@ describe('#rollupPlugin', () => {
             const bound = ssrPlugin.renderChunk.bind(t);
             const r = await bound('', { isEntry: true, facadeModuleId: files[0] });
             expect(r.code).toContain(`.content{content`);
-            expect(r.code).toContain(
-              `\\u002Felderjs\\u002Felderjs\\u002Ftest\\u002Fsrc\\u002Fcomponents\\u002FAutoComplete.svelte`,
-            );
+            expect(r.code).toContain(`\\u002Felderjs\\u002Ftest\\u002Fsrc\\u002Fcomponents\\u002FAutoComplete.svelte`);
             expect(r.code).toContain('AutoComplete.svelte"]');
           });
 

--- a/src/rollup/__tests__/rollupPlugin.test.ts
+++ b/src/rollup/__tests__/rollupPlugin.test.ts
@@ -95,29 +95,30 @@ describe('#rollupPlugin', () => {
     const { output: out } = await bundle.generate({ output });
 
     const css = out.find((c) => c.name === 'svelte.css');
+    console.log(css.source)
     expect(css.source).toContain(
-      `.layout.svelte-1e9whng{content:'we did it.'}.component.svelte-1hi7b3d{background:orange}`,
+      `.layout.svelte-1e9whng{content:'we did it.'}.component.svelte-1be6npj{background:orange}`,
     );
 
     // css with the same priority is non-deterministic in the tests
     // node_modules is lowest priority
     expect(
       css.source.includes(
-        `.icon.svelte-qg30r{background-color:#fff;border-radius:10px;width:10px;height:10px;color:#000}.button.svelte-zc2di4{padding:10px 20px;background-color:#f50;color:#fff;font-weight:700}.layout.svelte-1e9whng{content:'we did it.'}.component.svelte-1hi7b3d{background:orange}`,
+        `.icon.svelte-1kfpccr{background-color:#fff;border-radius:10px;width:10px;height:10px;color:#000}.button.svelte-11xgp0c{padding:10px 20px;background-color:#f50;color:#fff;font-weight:700}.layout.svelte-1e9whng{content:'we did it.'}.component.svelte-1be6npj{background:orange}`,
       ) ||
         css.source.includes(
-          `.button.svelte-zc2di4{padding:10px 20px;background-color:#f50;color:#fff;font-weight:700}.icon.svelte-qg30r{background-color:#fff;border-radius:10px;width:10px;height:10px;color:#000}.layout.svelte-1e9whng{content:'we did it.'}.component.svelte-1hi7b3d{background:orange}`,
+          `.button.svelte-11xgp0c{padding:10px 20px;background-color:#f50;color:#fff;font-weight:700}.icon.svelte-1kfpccr{background-color:#fff;border-radius:10px;width:10px;height:10px;color:#000}.layout.svelte-1e9whng{content:'we did it.'}.component.svelte-1be6npj{background:orange}`,
         ),
     ).toBe(true);
 
     const externalSvelte = out.find((c) => c.facadeModuleId && c.facadeModuleId.endsWith('External.svelte'));
     expect(externalSvelte.code).toContain(
-      ".button.svelte-zc2di4{padding:10px 20px;background-color:#f50;color:#fff;font-weight:700}.icon.svelte-qg30r{background-color:#fff;border-radius:10px;width:10px;height:10px;color:#000}.layout.svelte-1e9whng{content:'we did it.'}.component.svelte-1hi7b3d{background:orange}",
+      ".button.svelte-11xgp0c{padding:10px 20px;background-color:#f50;color:#fff;font-weight:700}.icon.svelte-1kfpccr{background-color:#fff;border-radius:10px;width:10px;height:10px;color:#000}.layout.svelte-1e9whng{content:'we did it.'}.component.svelte-1be6npj{background:orange}",
     );
 
     const componentSvelte = out.find((c) => c.facadeModuleId.endsWith('Component.svelte'));
     expect(componentSvelte.code).toContain(
-      '.button.svelte-zc2di4{padding:10px 20px;background-color:#f50;color:#fff;font-weight:700}.icon.svelte-qg30r{background-color:#fff;border-radius:10px;width:10px;height:10px;color:#000}.component.svelte-1hi7b3d{background:orange}',
+      '.icon.svelte-1kfpccr{background-color:#fff;border-radius:10px;width:10px;height:10px;color:#000}.component.svelte-1be6npj{background:orange}',
     );
 
     process.cwd = cwd;

--- a/src/rollup/__tests__/rollupPlugin.test.ts
+++ b/src/rollup/__tests__/rollupPlugin.test.ts
@@ -95,7 +95,6 @@ describe('#rollupPlugin', () => {
     const { output: out } = await bundle.generate({ output });
 
     const css = out.find((c) => c.name === 'svelte.css');
-    console.log(css.source)
     expect(css.source).toContain(
       `.layout.svelte-1e9whng{content:'we did it.'}.component.svelte-1be6npj{background:orange}`,
     );

--- a/src/rollup/rollupPlugin.ts
+++ b/src/rollup/rollupPlugin.ts
@@ -36,12 +36,23 @@ export function logDependency(importee, importer, memoryCache) {
   if (importee === 'svelte/internal' || importee === 'svelte') return;
   if (importer) {
     const parsedImporter = path.parse(importer);
+
+    // The following two expressions are used to determine if we are trying to import
+    // a svelte file from an external dependency and ensure that we add the correct path to that dependency
+    const externalDependencyImport = path.resolve(
+      parsedImporter.dir.substr(0, parsedImporter.dir.lastIndexOf('src/')),
+      'node_modules',
+      importee,
+    );
+    const isExternalDependency = fs.pathExistsSync(externalDependencyImport);
     if (!memoryCache.dependencies[importer]) memoryCache.dependencies[importer] = new Set();
     if (importee.includes('node_modules')) {
       memoryCache.dependencies[importer].add(importee);
     } else if (importer.includes('node_modules')) {
       const fullImportee = path.resolve(parsedImporter.dir, importee);
       memoryCache.dependencies[importer].add(fullImportee);
+    } else if (importee.includes('.svelte') && isExternalDependency) {
+      memoryCache.dependencies[importer].add(externalDependencyImport);
     } else if ((parsedImporter.ext === '.svelte' && importee.includes('.svelte')) || importee.includes('.css')) {
       const fullImportee = path.resolve(parsedImporter.dir, importee);
       memoryCache.dependencies[importer].add(fullImportee);
@@ -235,7 +246,6 @@ export default function elderjsRollup({
       // use pkg.svelte
       if (parts.length === 0 && pkg.svelte) {
         const svelteResolve = path.resolve(dir, pkg.svelte);
-        // console.log('-----------------', svelteResolve, name);
         logDependency(svelteResolve, name, cache);
         return svelteResolve;
       }
@@ -298,7 +308,6 @@ export default function elderjsRollup({
         if (type === 'ssr') {
           const trackedDeps = getDependencies(chunk.facadeModuleId, cache);
           // console.log(Object.keys(chunk.modules), trackedDeps);
-
           const cssEntries = getCssFromCache(trackedDeps, this.cache);
           const cssOutput = await prepareCss(cssEntries);
           code += `\nmodule.exports._css = ${devalue(cssOutput.styles)};`;

--- a/src/rollup/rollupPlugin.ts
+++ b/src/rollup/rollupPlugin.ts
@@ -246,6 +246,7 @@ export default function elderjsRollup({
       // use pkg.svelte
       if (parts.length === 0 && pkg.svelte) {
         const svelteResolve = path.resolve(dir, pkg.svelte);
+        // console.log('-----------------', svelteResolve, name);
         logDependency(svelteResolve, name, cache);
         return svelteResolve;
       }
@@ -308,6 +309,7 @@ export default function elderjsRollup({
         if (type === 'ssr') {
           const trackedDeps = getDependencies(chunk.facadeModuleId, cache);
           // console.log(Object.keys(chunk.modules), trackedDeps);
+
           const cssEntries = getCssFromCache(trackedDeps, this.cache);
           const cssOutput = await prepareCss(cssEntries);
           code += `\nmodule.exports._css = ${devalue(cssOutput.styles)};`;

--- a/src/rollup/rollupPlugin.ts
+++ b/src/rollup/rollupPlugin.ts
@@ -40,7 +40,7 @@ export function logDependency(importee, importer, memoryCache) {
     // The following two expressions are used to determine if we are trying to import
     // a svelte file from an external dependency and ensure that we add the correct path to that dependency
     const externalDependencyImport = path.resolve(
-      parsedImporter.dir.substr(0, parsedImporter.dir.lastIndexOf('src/')),
+      parsedImporter.dir.substr(0, parsedImporter.dir.lastIndexOf('src')),
       'node_modules',
       importee,
     );


### PR DESCRIPTION
This problem originates from that including an external component like
`import { Button } from 'test-external-svelte-library';`
where `test-external-svelte-library/index.js` contains
```
export { default as Button } from './components/Button.svelte'
export { default as Unused } from './components/Unused.svelte'
```
will cause the CSS to contain CSS from *all* exported components.

The solution is to import components like 

`import Button from 'test-external-svelte-library/src/components/Button.svelte';`

Importing components like this caused the `logDependency` function to add the wrong path to the cache, by concatenating the importers path with the path of this external component - causing a later cache miss with missing CSS as the result.

This PR modifies the `logDependency` function to check whether we possibly are dealing with such an externally imported component and adds that path to the cache instead.
