### PR TITLE
feat: 🎸 Use server.origin on build output

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -223,7 +223,7 @@ const hooks: Array<HookOptions> = [
     name: 'elderAddDefaultIntersectionObserver',
     description: 'Sets up the default polyfill for the intersection observer',
     priority: 100,
-    run: async ({ beforeHydrateStack }) => {
+    run: async ({ beforeHydrateStack, settings }) => {
       return {
         beforeHydrateStack: [
           {
@@ -231,7 +231,7 @@ const hooks: Array<HookOptions> = [
             string: `<script type="text/javascript">
       if (!('IntersectionObserver' in window)) {
           var script = document.createElement("script");
-          script.src = "/_elderjs/static/intersection-observer.js";
+          script.src = "${settings.$$internal.serverPrefix}/_elderjs/static/intersection-observer.js";
           document.getElementsByTagName('head')[0].appendChild(script);
       };
       </script>

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -15,10 +15,12 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
   }
   const config: SettingsOptions = defaultsDeep(initializationOptions, loadedConfig, getDefaultConfig());
 
+  const serverPrefix = loadedConfig.server.prefix || '';
+
   const rootDir = config.rootDir === 'process.cwd()' ? process.cwd() : path.resolve(config.rootDir);
   config.rootDir = rootDir;
   config.srcDir = path.resolve(rootDir, `./${config.srcDir}`);
-  config.distDir = path.resolve(rootDir, `./${config.distDir}`);
+  config.distDir = path.resolve(rootDir, path.join(`./${config.distDir}`, `${serverPrefix}/`));
 
   config.context = typeof initializationOptions.context !== 'undefined' ? initializationOptions.context : 'unknown';
   config.server = initializationOptions.context === 'server' && config.server;
@@ -29,12 +31,14 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
   const clientComponents = path.resolve(config.distDir, './_elderjs/svelte/');
   const distElder = path.resolve(config.distDir, './_elderjs/');
   fs.ensureDirSync(path.resolve(distElder));
+  fs.ensureDirSync(path.resolve(clientComponents));
 
   config.$$internal = {
     ssrComponents,
     clientComponents,
     distElder,
     prefix: `[Elder.js]:`,
+    serverPrefix,
     findComponent: prepareFindSvelteComponent({
       ssrFolder: ssrComponents,
       rootDir,
@@ -53,7 +57,7 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
       );
     }
     if (cssFiles[0]) {
-      config.$$internal.publicCssFile = `/_elderjs/assets/${cssFiles[0]}`;
+      config.$$internal.publicCssFile = `${serverPrefix}/_elderjs/assets/${cssFiles[0]}`;
     } else {
       console.error(`CSS file not found in ${assetPath}`);
     }

--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -7,9 +7,8 @@
  */
 const permalinks = ({ routes, settings }) =>
   Object.keys(routes).reduce((out, cv) => {
-    const prefix = settings.server && settings.server.prefix ? settings.server.prefix : '';
     // eslint-disable-next-line no-param-reassign
-    out[cv] = (data) => `${prefix}${routes[cv].permalink({ request: data, settings })}`;
+    out[cv] = (data) => `${settings.$$internal.serverPrefix}${routes[cv].permalink({ request: data, settings })}`;
     return out;
   }, {});
 

--- a/src/utils/svelteComponent.ts
+++ b/src/utils/svelteComponent.ts
@@ -41,7 +41,7 @@ const svelteComponent = (componentName: String, folder: String = 'components') =
     return hydrateComponent({
       page,
       iife,
-      clientSrcMjs: client,
+      clientSrcMjs: `${page.settings.$$internal.serverPrefix}/${client}`,
       innerHtml: mountComponentsInHtml({ html: htmlOutput, page, hydrateOptions }),
       hydrateOptions,
       componentName: cleanComponentName,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -32,6 +32,7 @@ type Internal = {
   clientComponents: string;
   distElder: string;
   prefix: string;
+  serverPrefix: string;
   findComponent: FindSvelteComponent;
   publicCssFile?: string;
 };


### PR DESCRIPTION
Closes https://github.com/Elderjs/elderjs/issues/120
Requires https://github.com/Elderjs/template/pull/40

Now we can use the config `server.prefix` to the path prefix.
For example: on the route `www.example.com/foo`, the prefix is `foo`.

It's useful if you are developing a github/gitlab pages or a legacy application that just a route should work with Elder.js