### PR TITLE
Rework server prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build/
 
 .DS_store
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -8160,6 +8160,11 @@
       "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA=="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elderjs/elderjs",
-  "version": "1.2.2",
+  "version": "1.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",
     "lodash.defaultsdeep": "^4.6.1",
+    "lodash.get": "^4.4.2",
     "lodash.kebabcase": "^4.1.1",
     "nanoid": "^3.1.12",
     "rollup": "^2.21.0",

--- a/src/Elder.ts
+++ b/src/Elder.ts
@@ -311,9 +311,9 @@ class Elder {
             helpers: createReadOnlyProxy(this.helpers, 'helpers', `${request.route} permalink function`),
           });
 
-          if (this.settings && this.settings.server && this.settings.server.prefix) {
-            request.permalink = this.settings.server.prefix + request.permalink;
-          }
+          // if (this.settings && this.settings.server && this.settings.server.prefix) {
+          //   request.permalink = this.settings.server.prefix + request.permalink;
+          // }
 
           if (this.settings.context === 'server') {
             this.serverLookupObject[request.permalink] = request;

--- a/src/Elder.ts
+++ b/src/Elder.ts
@@ -311,10 +311,6 @@ class Elder {
             helpers: createReadOnlyProxy(this.helpers, 'helpers', `${request.route} permalink function`),
           });
 
-          // if (this.settings && this.settings.server && this.settings.server.prefix) {
-          //   request.permalink = this.settings.server.prefix + request.permalink;
-          // }
-
           if (this.settings.context === 'server') {
             this.serverLookupObject[request.permalink] = request;
           }

--- a/src/__tests__/__snapshots__/Elder.spec.ts.snap
+++ b/src/__tests__/__snapshots__/Elder.spec.ts.snap
@@ -652,7 +652,7 @@ exports[`#Elder srcPlugin found 1`] = `
 Object {
   "allRequests": Array [
     Object {
-      "permalink": "/dev/",
+      "permalink": "/",
       "route": "test-a",
       "slug": "/test",
       "type": "server",
@@ -1301,8 +1301,8 @@ Object {
   "runHook": [Function],
   "server": [Function],
   "serverLookupObject": Object {
-    "/dev/": Object {
-      "permalink": "/dev/",
+    "/": Object {
+      "permalink": "/",
       "route": "test-a",
       "slug": "/test",
       "type": "server",

--- a/src/hooks/__tests__/__snapshots__/hooks.spec.ts.snap
+++ b/src/hooks/__tests__/__snapshots__/hooks.spec.ts.snap
@@ -19,25 +19,6 @@ Object {
 }
 `;
 
-exports[`#hooks elderAddDefaultIntersectionObserver with prefix 1`] = `
-Object {
-  "beforeHydrateStack": Array [
-    Object {
-      "priority": 100,
-      "source": "elderAddDefaultIntersectionObserver",
-      "string": "<script type=\\"text/javascript\\">
-      if (!('IntersectionObserver' in window)) {
-          var script = document.createElement(\\"script\\");
-          script.src = \\"/_elderjs/static/intersection-observer.js\\";
-          document.getElementsByTagName('head')[0].appendChild(script);
-      };
-      </script>
-      ",
-    },
-  ],
-}
-`;
-
 exports[`#hooks elderAddExternalHelpers 1`] = `
 Object {
   "helpers": Object {

--- a/src/hooks/__tests__/__snapshots__/hooks.spec.ts.snap
+++ b/src/hooks/__tests__/__snapshots__/hooks.spec.ts.snap
@@ -19,6 +19,25 @@ Object {
 }
 `;
 
+exports[`#hooks elderAddDefaultIntersectionObserver with prefix 1`] = `
+Object {
+  "beforeHydrateStack": Array [
+    Object {
+      "priority": 100,
+      "source": "elderAddDefaultIntersectionObserver",
+      "string": "<script type=\\"text/javascript\\">
+      if (!('IntersectionObserver' in window)) {
+          var script = document.createElement(\\"script\\");
+          script.src = \\"/_elderjs/static/intersection-observer.js\\";
+          document.getElementsByTagName('head')[0].appendChild(script);
+      };
+      </script>
+      ",
+    },
+  ],
+}
+`;
+
 exports[`#hooks elderAddExternalHelpers 1`] = `
 Object {
   "helpers": Object {

--- a/src/hooks/__tests__/hooks.spec.ts
+++ b/src/hooks/__tests__/hooks.spec.ts
@@ -44,8 +44,8 @@ describe('#hooks', () => {
     const hook = hooks.find((h) => h.name === 'elderExpressLikeMiddleware');
     const next = () => 'next() was called';
     const settings = {
-      server: {
-        prefix: '/dev',
+      $$internal: {
+        serverPrefix: '/dev',
       },
     };
     // prefix not found

--- a/src/hooks/__tests__/hooks.spec.ts
+++ b/src/hooks/__tests__/hooks.spec.ts
@@ -120,6 +120,16 @@ describe('#hooks', () => {
     const hook = hooks.find((h) => h.name === 'elderAddDefaultIntersectionObserver');
     expect(normalizeSnapshot(await hook.run({ beforeHydrateStack: [] }))).toMatchSnapshot();
   });
+  it('elderAddDefaultIntersectionObserver with prefix', async () => {
+    const hook = hooks.find((h) => h.name === 'elderAddDefaultIntersectionObserver');
+    const settings = {
+      $$internal: {
+        serverPrefix: '/dev',
+      },
+    };
+    const result = await hook.run({ beforeHydrateStack: [], settings });
+    expect(result.beforeHydrateStack[0].string).toContain('/dev/_elderjs/static/intersection-observer.js');
+  });
   it('elderCompileHtml', async () => {
     const hook = hooks.find((h) => h.name === 'elderCompileHtml');
     expect(

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable consistent-return */
 import path from 'path';
 import fs from 'fs-extra';
+import get from 'lodash.get';
 import { parseBuildPerf } from '../utils';
 import externalHelpers from '../externalHelpers';
 import { HookOptions } from './types';
@@ -53,9 +54,10 @@ const hooks: Array<HookOptions> = [
     }) => {
       if (req.path) {
         let reqPath = req.path;
+        const prefix = get(settings, '$$internal.serverPrefix', '');
 
-        if (settings.$$internal.serverPrefix && settings.$$internal.serverPrefix.length > 0) {
-          if (reqPath.indexOf(settings.$$internal.serverPrefix) !== 0) {
+        if (prefix && prefix.length > 0) {
+          if (reqPath.indexOf(prefix) !== 0) {
             return next();
           }
         }
@@ -224,6 +226,8 @@ const hooks: Array<HookOptions> = [
     description: 'Sets up the default polyfill for the intersection observer',
     priority: 100,
     run: async ({ beforeHydrateStack, settings }) => {
+      const prefix = get(settings, '$$internal.serverPrefix', '');
+
       return {
         beforeHydrateStack: [
           {
@@ -231,7 +235,7 @@ const hooks: Array<HookOptions> = [
             string: `<script type="text/javascript">
       if (!('IntersectionObserver' in window)) {
           var script = document.createElement("script");
-          script.src = "${settings.$$internal.serverPrefix}/_elderjs/static/intersection-observer.js";
+          script.src = "${prefix}/_elderjs/static/intersection-observer.js";
           document.getElementsByTagName('head')[0].appendChild(script);
       };
       </script>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -54,8 +54,8 @@ const hooks: Array<HookOptions> = [
       if (req.path) {
         let reqPath = req.path;
 
-        if (settings.server.prefix && settings.server.prefix.length > 0) {
-          if (reqPath.indexOf(settings.server.prefix) !== 0) {
+        if (settings.prefix && settings.prefix.length > 0) {
+          if (reqPath.indexOf(settings.prefix) !== 0) {
             return next();
           }
         }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -226,6 +226,7 @@ const hooks: Array<HookOptions> = [
     description: 'Sets up the default polyfill for the intersection observer',
     priority: 100,
     run: async ({ beforeHydrateStack, settings }) => {
+      console.log('HOOK SETTINGS:', settings);
       const prefix = get(settings, '$$internal.serverPrefix', '');
 
       return {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -223,7 +223,7 @@ const hooks: Array<HookOptions> = [
     name: 'elderAddDefaultIntersectionObserver',
     description: 'Sets up the default polyfill for the intersection observer',
     priority: 100,
-    run: async ({ beforeHydrateStack }) => {
+    run: async ({ beforeHydrateStack, settings }) => {
       return {
         beforeHydrateStack: [
           {
@@ -231,7 +231,7 @@ const hooks: Array<HookOptions> = [
             string: `<script type="text/javascript">
       if (!('IntersectionObserver' in window)) {
           var script = document.createElement("script");
-          script.src = "/_elderjs/static/intersection-observer.js";
+          script.src = "${settings.$$internal.serverPrefix}/_elderjs/static/intersection-observer.js";
           document.getElementsByTagName('head')[0].appendChild(script);
       };
       </script>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -226,7 +226,6 @@ const hooks: Array<HookOptions> = [
     description: 'Sets up the default polyfill for the intersection observer',
     priority: 100,
     run: async ({ beforeHydrateStack, settings }) => {
-      console.log('HOOK SETTINGS:', settings);
       const prefix = get(settings, '$$internal.serverPrefix', '');
 
       return {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -54,8 +54,8 @@ const hooks: Array<HookOptions> = [
       if (req.path) {
         let reqPath = req.path;
 
-        if (settings.prefix && settings.prefix.length > 0) {
-          if (reqPath.indexOf(settings.prefix) !== 0) {
+        if (settings.$$internal.prefix && settings.$$internal.prefix.length > 0) {
+          if (reqPath.indexOf(settings.$$internal.prefix) !== 0) {
             return next();
           }
         }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -54,8 +54,8 @@ const hooks: Array<HookOptions> = [
       if (req.path) {
         let reqPath = req.path;
 
-        if (settings.$$internal.prefix && settings.$$internal.prefix.length > 0) {
-          if (reqPath.indexOf(settings.$$internal.prefix) !== 0) {
+        if (settings.$$internal.serverPrefix && settings.$$internal.serverPrefix.length > 0) {
+          if (reqPath.indexOf(settings.$$internal.serverPrefix) !== 0) {
             return next();
           }
         }

--- a/src/rollup/getRollupConfig.ts
+++ b/src/rollup/getRollupConfig.ts
@@ -13,6 +13,7 @@ import { getElderConfig } from '../index';
 import { getDefaultRollup } from '../utils/validations';
 import getPluginLocations from '../utils/getPluginLocations';
 import elderSvelte from './rollupPlugin';
+import normalizePrefix from '../utils/normalizePrefix';
 
 const production = process.env.NODE_ENV === 'production' || !process.env.ROLLUP_WATCH;
 const elderJsDir = path.resolve(process.cwd(), './node_modules/@elderjs/elderjs/');
@@ -153,11 +154,12 @@ export default function getRollupConfig(options) {
     if (!fs.existsSync(path.resolve(elderConfig.rootDir, dep[0]))) {
       throw new Error(`Elder.js peer dependency not found at ${dep[0]}`);
     }
+    const prefix = normalizePrefix(elderConfig.prefix);
     configs.push({
       input: dep[0],
       output: [
         {
-          file: path.resolve(elderConfig.distDir, dep[1]),
+          file: path.resolve(prefix ? elderConfig.distDir + prefix : elderConfig.distDir, dep[1]),
           format: 'iife',
           name: dep[1],
           plugins: [terser()],

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -71,7 +71,9 @@ function routes(settings: SettingsOptions) {
       // not defined, look for a svelte file...
       const svelteFile = filesForThisRoute.find((f) => f.endsWith(`/routes/${routeName}/${capitalizedRoute}.svelte`));
       if (settings.debug.automagic) {
-        console.log(`${logPrefix} No template defined for /routes/${routeName}/ looking for ${capitalizedRoute}.svelte`);
+        console.log(
+          `${logPrefix} No template defined for /routes/${routeName}/ looking for ${capitalizedRoute}.svelte`,
+        );
       }
 
       if (svelteFile) {

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -12,7 +12,7 @@ import wrapPermalinkFn from '../utils/wrapPermalinkFn';
 function routes(settings: SettingsOptions) {
   const files = glob.sync(`${settings.srcDir}/routes/*/+(*.js|*.svelte)`);
 
-  const { ssrComponents: ssrFolder, prefix } = settings.$$internal;
+  const { ssrComponents: ssrFolder, logPrefix } = settings.$$internal;
 
   const ssrComponents = glob.sync(`${ssrFolder}/**/*.js`);
 
@@ -31,7 +31,7 @@ function routes(settings: SettingsOptions) {
     if (!route.permalink) {
       if (settings.debug.automagic) {
         console.log(
-          `${prefix} No permalink function found for route "${routeName}". Setting default which will return / for home or /{request.slug}/.`,
+          `${logPrefix} No permalink function found for route "${routeName}". Setting default which will return / for home or /{request.slug}/.`,
         );
       }
       route.permalink = ({ request }) => (request.slug === '/' ? request.slug : `/${request.slug}/`);
@@ -48,7 +48,7 @@ function routes(settings: SettingsOptions) {
 
       if (settings.debug.automagic) {
         console.log(
-          `${prefix} No all function or array found for route "${routeName}". Setting default which will return ${JSON.stringify(
+          `${logPrefix} No all function or array found for route "${routeName}". Setting default which will return ${JSON.stringify(
             route.all,
           )}`,
         );
@@ -71,7 +71,7 @@ function routes(settings: SettingsOptions) {
       // not defined, look for a svelte file...
       const svelteFile = filesForThisRoute.find((f) => f.endsWith(`/routes/${routeName}/${capitalizedRoute}.svelte`));
       if (settings.debug.automagic) {
-        console.log(`${prefix} No template defined for /routes/${routeName}/ looking for ${capitalizedRoute}.svelte`);
+        console.log(`${logPrefix} No template defined for /routes/${routeName}/ looking for ${capitalizedRoute}.svelte`);
       }
 
       if (svelteFile) {
@@ -115,7 +115,7 @@ function routes(settings: SettingsOptions) {
     } else {
       if (settings.debug.automagic) {
         console.log(
-          `${prefix} The route at /routes/${routeName}/route.js doesn't have a layout specified so going to look for a Layout.svelte file.`,
+          `${logPrefix} The route at /routes/${routeName}/route.js doesn't have a layout specified so going to look for a Layout.svelte file.`,
         );
       }
       route.layout = 'Layout.svelte';

--- a/src/utils/__tests__/__snapshots__/validations.spec.ts.snap
+++ b/src/utils/__tests__/__snapshots__/validations.spec.ts.snap
@@ -18,6 +18,7 @@ Object {
     "plugins",
     "shortcodes",
     "build",
+    "prefix",
     "server",
     "hooks",
     "debug",
@@ -606,6 +607,33 @@ Object {
       ],
       "type": "object",
     },
+    "prefix": Object {
+      "_blacklist": Object {
+        "list": Set {},
+        "refs": Map {},
+      },
+      "_conditions": Array [],
+      "_default": "",
+      "_deps": Array [],
+      "_exclusive": Object {},
+      "_label": "If Elder.js should serve all pages with a prefix.",
+      "_mutate": undefined,
+      "_options": Object {
+        "abortEarly": true,
+        "recursive": true,
+      },
+      "_type": "string",
+      "_typeError": [Function],
+      "_whitelist": Object {
+        "list": Set {},
+        "refs": Map {},
+      },
+      "tests": Array [],
+      "transforms": Array [
+        [Function],
+      ],
+      "type": "string",
+    },
     "rootDir": Object {
       "_blacklist": Object {
         "list": Set {},
@@ -667,7 +695,7 @@ Object {
           "_default": "",
           "_deps": Array [],
           "_exclusive": Object {},
-          "_label": "If Elder.js should serve all pages with a prefix.",
+          "_label": "If Elder.js should serve all pages with a prefix. (deprecated)",
           "_mutate": undefined,
           "_options": Object {
             "abortEarly": true,

--- a/src/utils/__tests__/getConfig.spec.ts
+++ b/src/utils/__tests__/getConfig.spec.ts
@@ -117,7 +117,7 @@ describe('#getConfig', () => {
       clientComponents: resolve(process.cwd(), `./t/public/_elderjs/svelte`),
       distElder: resolve(process.cwd(), `./t/public/_elderjs`),
       // findComponent: () => {},
-      prefix: '[Elder.js]:',
+      logPrefix: '[Elder.js]:',
     };
 
     it('gives back a custom context such as serverless', () => {

--- a/src/utils/__tests__/getConfig.spec.ts
+++ b/src/utils/__tests__/getConfig.spec.ts
@@ -43,7 +43,7 @@ describe('#getConfig', () => {
       clientComponents: resolve(process.cwd(), `./public/_elderjs/svelte`),
       distElder: resolve(process.cwd(), `./public/_elderjs`),
       // findComponent: () => {},
-      prefix: '[Elder.js]:',
+      logPrefix: '[Elder.js]:',
       serverPrefix: '',
     },
     build: false,

--- a/src/utils/__tests__/getConfig.spec.ts
+++ b/src/utils/__tests__/getConfig.spec.ts
@@ -59,6 +59,7 @@ describe('#getConfig', () => {
     rootDir: process.cwd(),
     srcDir: resolve(process.cwd(), './src'),
     server: false,
+    prefix: '',
     shortcodes: {
       closePattern: '}}',
       openPattern: '{{',
@@ -149,15 +150,13 @@ describe('#getConfig', () => {
         expect.objectContaining({
           ...common,
           context: 'server',
-          server: {
-            prefix: '',
-          },
+          server: false,
         }),
       );
       expect(r.$$internal).toMatchObject(common$$Internal);
     });
 
-    it('it sets a server with a prefix', () => {
+    it('it sets a server with a server.prefix without leading or trailing "/"', () => {
       jest.mock('fs-extra', () => {
         return {
           ensureDirSync: () => {},
@@ -170,12 +169,193 @@ describe('#getConfig', () => {
           ...common,
           context: 'server',
           server: {
-            prefix: 'testing',
+            prefix: '/testing',
           },
+          prefix: '/testing',
         }),
       );
-      expect(r.$$internal).toMatchObject(common$$Internal);
+      expect(r.$$internal).toMatchObject({
+        ...common$$Internal,
+        clientComponents: resolve(process.cwd(), `./t/public/testing/_elderjs/svelte`),
+        distElder: resolve(process.cwd(), `./t/public/testing/_elderjs`),
+      });
     });
+
+    it('it sets a server with a server.prefix with a trailing "/"', () => {
+      jest.mock('fs-extra', () => {
+        return {
+          ensureDirSync: () => {},
+          readdirSync: () => ['svelte-3449427d.css', 'svelte.css-0050caf1.map'],
+        };
+      });
+      const r = getConfig({ context: 'server', server: { prefix: 'testing/' }, rootDir: 't' });
+      expect(r).toStrictEqual(
+        expect.objectContaining({
+          ...common,
+          context: 'server',
+          server: {
+            prefix: '/testing',
+          },
+          prefix: '/testing',
+        }),
+      );
+      expect(r.$$internal).toMatchObject({
+        ...common$$Internal,
+        clientComponents: resolve(process.cwd(), `./t/public/testing/_elderjs/svelte`),
+        distElder: resolve(process.cwd(), `./t/public/testing/_elderjs`),
+      });
+    });
+
+    it('it sets a server with a server.prefix with a leading "/"', () => {
+      jest.mock('fs-extra', () => {
+        return {
+          ensureDirSync: () => {},
+          readdirSync: () => ['svelte-3449427d.css', 'svelte.css-0050caf1.map'],
+        };
+      });
+      const r = getConfig({ context: 'server', server: { prefix: '/testing' }, rootDir: 't' });
+      expect(r).toStrictEqual(
+        expect.objectContaining({
+          ...common,
+          context: 'server',
+          server: {
+            prefix: '/testing',
+          },
+          prefix: '/testing',
+        }),
+      );
+      expect(r.$$internal).toMatchObject({
+        ...common$$Internal,
+        clientComponents: resolve(process.cwd(), `./t/public/testing/_elderjs/svelte`),
+        distElder: resolve(process.cwd(), `./t/public/testing/_elderjs`),
+      });
+    });
+
+    it('it sets a server with a server.prefix with a leading and trailing "/"', () => {
+      jest.mock('fs-extra', () => {
+        return {
+          ensureDirSync: () => {},
+          readdirSync: () => ['svelte-3449427d.css', 'svelte.css-0050caf1.map'],
+        };
+      });
+      const r = getConfig({ context: 'server', server: { prefix: '/testing/' }, rootDir: 't' });
+      expect(r).toStrictEqual(
+        expect.objectContaining({
+          ...common,
+          context: 'server',
+          server: {
+            prefix: '/testing',
+          },
+          prefix: '/testing',
+        }),
+      );
+      expect(r.$$internal).toMatchObject({
+        ...common$$Internal,
+        clientComponents: resolve(process.cwd(), `./t/public/testing/_elderjs/svelte`),
+        distElder: resolve(process.cwd(), `./t/public/testing/_elderjs`),
+      });
+    });
+
+    it('it sets a server with a prefix without a leading or trailing "/"', () => {
+      jest.mock('fs-extra', () => {
+        return {
+          ensureDirSync: () => {},
+          readdirSync: () => ['svelte-3449427d.css', 'svelte.css-0050caf1.map'],
+        };
+      });
+      const r = getConfig({ context: 'server', prefix: 'testing', rootDir: 't' });
+      expect(r).toStrictEqual(
+        expect.objectContaining({
+          ...common,
+          context: 'server',
+          server: {
+            prefix: '/testing',
+          },
+          prefix: '/testing',
+        }),
+      );
+      expect(r.$$internal).toMatchObject({
+        ...common$$Internal,
+        clientComponents: resolve(process.cwd(), `./t/public/testing/_elderjs/svelte`),
+        distElder: resolve(process.cwd(), `./t/public/testing/_elderjs`),
+      });
+    });
+
+    it('it sets a server with a prefix with a leading "/"', () => {
+      jest.mock('fs-extra', () => {
+        return {
+          ensureDirSync: () => {},
+          readdirSync: () => ['svelte-3449427d.css', 'svelte.css-0050caf1.map'],
+        };
+      });
+      const r = getConfig({ context: 'server', prefix: '/testing', rootDir: 't' });
+      expect(r).toStrictEqual(
+        expect.objectContaining({
+          ...common,
+          context: 'server',
+          server: {
+            prefix: '/testing',
+          },
+          prefix: '/testing',
+        }),
+      );
+      expect(r.$$internal).toMatchObject({
+        ...common$$Internal,
+        clientComponents: resolve(process.cwd(), `./t/public/testing/_elderjs/svelte`),
+        distElder: resolve(process.cwd(), `./t/public/testing/_elderjs`),
+      });
+    });
+
+    it('it sets a server with a prefix with a trailing "/"', () => {
+      jest.mock('fs-extra', () => {
+        return {
+          ensureDirSync: () => {},
+          readdirSync: () => ['svelte-3449427d.css', 'svelte.css-0050caf1.map'],
+        };
+      });
+      const r = getConfig({ context: 'server', prefix: '/testing/', rootDir: 't' });
+      expect(r).toStrictEqual(
+        expect.objectContaining({
+          ...common,
+          context: 'server',
+          server: {
+            prefix: '/testing',
+          },
+          prefix: '/testing',
+        }),
+      );
+      expect(r.$$internal).toMatchObject({
+        ...common$$Internal,
+        clientComponents: resolve(process.cwd(), `./t/public/testing/_elderjs/svelte`),
+        distElder: resolve(process.cwd(), `./t/public/testing/_elderjs`),
+      });
+    });
+
+    it('it sets a server with a prefix with a leading and trailing "/"', () => {
+      jest.mock('fs-extra', () => {
+        return {
+          ensureDirSync: () => {},
+          readdirSync: () => ['svelte-3449427d.css', 'svelte.css-0050caf1.map'],
+        };
+      });
+      const r = getConfig({ context: 'server', prefix: '/testing/', rootDir: 't' });
+      expect(r).toStrictEqual(
+        expect.objectContaining({
+          ...common,
+          context: 'server',
+          server: {
+            prefix: '/testing',
+          },
+          prefix: '/testing',
+        }),
+      );
+      expect(r.$$internal).toMatchObject({
+        ...common$$Internal,
+        clientComponents: resolve(process.cwd(), `./t/public/testing/_elderjs/svelte`),
+        distElder: resolve(process.cwd(), `./t/public/testing/_elderjs`),
+      });
+    });
+
     it('it sets build with default', () => {
       jest.mock('fs-extra', () => {
         return {

--- a/src/utils/__tests__/getConfig.spec.ts
+++ b/src/utils/__tests__/getConfig.spec.ts
@@ -44,6 +44,7 @@ describe('#getConfig', () => {
       distElder: resolve(process.cwd(), `./public/_elderjs`),
       // findComponent: () => {},
       prefix: '[Elder.js]:',
+      serverPrefix: '',
     },
     build: false,
     debug: {

--- a/src/utils/__tests__/normalizePrefix.spec.ts
+++ b/src/utils/__tests__/normalizePrefix.spec.ts
@@ -1,0 +1,35 @@
+import normalizePrefix from '../normalizePrefix';
+
+describe('#normalizePrefix', () => {
+  const correctPrefix = '/testing';
+
+  it('returns correct prefix providing a prefix without leading and trailing "/"', () => {
+    const result = normalizePrefix('testing');
+
+    expect(result).toEqual(correctPrefix);
+  });
+
+  it('returns correct prefix providing a prefix with a leading "/"', () => {
+    const result = normalizePrefix('/testing');
+
+    expect(result).toEqual(correctPrefix);
+  });
+
+  it('returns correct prefix providing a prefix with a trailing "/"', () => {
+    const result = normalizePrefix('testing/');
+
+    expect(result).toEqual(correctPrefix);
+  });
+
+  it('returns correct prefix providing a prefix with leading and trailing "/"', () => {
+    const result = normalizePrefix('/testing/');
+
+    expect(result).toEqual(correctPrefix);
+  });
+
+  it('returns correct prefix providing a prefix with multiple trailing "/"', () => {
+    const result = normalizePrefix('testing//');
+
+    expect(result).toEqual(correctPrefix);
+  });
+});

--- a/src/utils/__tests__/permalinks.spec.ts
+++ b/src/utils/__tests__/permalinks.spec.ts
@@ -17,12 +17,12 @@ describe('#permalinks', () => {
     expect(plinks.blog()).toEqual('/blog/');
     expect(plinks.home()).toEqual('/');
   });
-  it('works with server prefix', () => {
-    const settings = { server: { prefix: '/pages' } };
-    const plinks: any = permalinks({ routes, settings });
-    expect(plinks.blog()).toEqual('/pages/blog/');
-    expect(plinks.home()).toEqual('/pages/');
-  });
+  // it('works with server prefix', () => {
+  //   const settings = { server: { prefix: '/pages' } };
+  //   const plinks: any = permalinks({ routes, settings });
+  //   expect(plinks.blog()).toEqual('/pages/blog/');
+  //   expect(plinks.home()).toEqual('/pages/');
+  // });
   it('works with passing data', () => {
     const settings = {};
     const plinks: any = permalinks({ routes, settings });

--- a/src/utils/__tests__/permalinks.spec.ts
+++ b/src/utils/__tests__/permalinks.spec.ts
@@ -17,12 +17,18 @@ describe('#permalinks', () => {
     expect(plinks.blog()).toEqual('/blog/');
     expect(plinks.home()).toEqual('/');
   });
-  // it('works with server prefix', () => {
-  //   const settings = { server: { prefix: '/pages' } };
-  //   const plinks: any = permalinks({ routes, settings });
-  //   expect(plinks.blog()).toEqual('/pages/blog/');
-  //   expect(plinks.home()).toEqual('/pages/');
-  // });
+  it('works with server.prefix (deprecated)', () => {
+    const settings = { server: { prefix: '/pages' } };
+    const plinks: any = permalinks({ routes, settings });
+    expect(plinks.blog()).toEqual('/pages/blog/');
+    expect(plinks.home()).toEqual('/pages/');
+  });
+  it('works with prefix', () => {
+    const settings = { prefix: '/pages' };
+    const plinks: any = permalinks({ routes, settings });
+    expect(plinks.blog()).toEqual('/pages/blog/');
+    expect(plinks.home()).toEqual('/pages/');
+  });
   it('works with passing data', () => {
     const settings = {};
     const plinks: any = permalinks({ routes, settings });

--- a/src/utils/__tests__/validations.spec.ts
+++ b/src/utils/__tests__/validations.spec.ts
@@ -46,6 +46,7 @@ describe('#validations', () => {
     origin: '',
     lang: 'en',
     plugins: {},
+    prefix: '',
     server: {
       prefix: '',
     },

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -2,6 +2,7 @@ import { cosmiconfigSync } from 'cosmiconfig';
 import defaultsDeep from 'lodash.defaultsdeep';
 import path from 'path';
 import fs from 'fs-extra';
+import get from 'lodash.get';
 import { SettingsOptions, InitializationOptions } from './types';
 import { getDefaultConfig } from './validations';
 import prepareFindSvelteComponent from '../partialHydration/prepareFindSvelteComponent';
@@ -16,7 +17,7 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
   }
   const config: SettingsOptions = defaultsDeep(initializationOptions, loadedConfig, getDefaultConfig());
 
-  const serverPrefix = normalizePrefix(loadedConfig.prefix || loadedConfig.server.prefix);
+  const serverPrefix = normalizePrefix(loadedConfig.prefix || get(loadedConfig, 'server.prefix', ''));
 
   const rootDir = config.rootDir === 'process.cwd()' ? process.cwd() : path.resolve(config.rootDir);
   config.rootDir = rootDir;

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -5,6 +5,7 @@ import fs from 'fs-extra';
 import { SettingsOptions, InitializationOptions } from './types';
 import { getDefaultConfig } from './validations';
 import prepareFindSvelteComponent from '../partialHydration/prepareFindSvelteComponent';
+import normalizePrefix from './normalizePrefix';
 
 function getConfig(initializationOptions: InitializationOptions = {}): SettingsOptions {
   let loadedConfig: InitializationOptions = {};
@@ -15,12 +16,12 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
   }
   const config: SettingsOptions = defaultsDeep(initializationOptions, loadedConfig, getDefaultConfig());
 
-  const serverPrefix = loadedConfig.server.prefix || '';
+  const serverPrefix = normalizePrefix(loadedConfig.prefix || loadedConfig.server.prefix);
 
   const rootDir = config.rootDir === 'process.cwd()' ? process.cwd() : path.resolve(config.rootDir);
   config.rootDir = rootDir;
   config.srcDir = path.resolve(rootDir, `./${config.srcDir}`);
-  config.distDir = path.resolve(rootDir, path.join(`./${config.distDir}`, `${serverPrefix}/`));
+  config.distDir = path.resolve(rootDir, path.join(`./${config.distDir}`, `${serverPrefix}`));
 
   config.context = typeof initializationOptions.context !== 'undefined' ? initializationOptions.context : 'unknown';
   config.server = initializationOptions.context === 'server' && config.server;
@@ -28,8 +29,8 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
   config.worker = !!initializationOptions.worker;
 
   const ssrComponents = path.resolve(config.rootDir, './___ELDER___/compiled/');
-  const clientComponents = path.resolve(config.distDir, './_elderjs/svelte/');
-  const distElder = path.resolve(config.distDir, './_elderjs/');
+  const clientComponents = path.resolve(config.distDir, `.${serverPrefix}/_elderjs/svelte/`);
+  const distElder = path.resolve(config.distDir, `.${serverPrefix}/_elderjs/`);
   fs.ensureDirSync(path.resolve(distElder));
   fs.ensureDirSync(path.resolve(clientComponents));
 

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -15,10 +15,12 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
   }
   const config: SettingsOptions = defaultsDeep(initializationOptions, loadedConfig, getDefaultConfig());
 
+  const serverPrefix = loadedConfig.server.prefix || '';
+
   const rootDir = config.rootDir === 'process.cwd()' ? process.cwd() : path.resolve(config.rootDir);
   config.rootDir = rootDir;
   config.srcDir = path.resolve(rootDir, `./${config.srcDir}`);
-  config.distDir = path.resolve(rootDir, `./${config.distDir}`);
+  config.distDir = path.resolve(rootDir, path.join(`./${config.distDir}`, `${serverPrefix}/`));
 
   config.context = typeof initializationOptions.context !== 'undefined' ? initializationOptions.context : 'unknown';
   config.server = initializationOptions.context === 'server' && config.server;
@@ -29,12 +31,14 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
   const clientComponents = path.resolve(config.distDir, './_elderjs/svelte/');
   const distElder = path.resolve(config.distDir, './_elderjs/');
   fs.ensureDirSync(path.resolve(distElder));
+  fs.ensureDirSync(path.resolve(clientComponents));
 
   config.$$internal = {
     ssrComponents,
     clientComponents,
     distElder,
     prefix: `[Elder.js]:`,
+    serverPrefix,
     findComponent: prepareFindSvelteComponent({
       ssrFolder: ssrComponents,
       rootDir,
@@ -53,7 +57,7 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
       );
     }
     if (cssFiles[0]) {
-      config.$$internal.publicCssFile = `/_elderjs/assets/${cssFiles[0]}`;
+      config.$$internal.publicCssFile = `${serverPrefix}/_elderjs/assets/${cssFiles[0]}`;
     } else {
       console.error(`CSS file not found in ${assetPath}`);
     }

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -39,7 +39,7 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
     ssrComponents,
     clientComponents,
     distElder,
-    prefix: `[Elder.js]:`,
+    logPrefix: `[Elder.js]:`,
     serverPrefix,
     findComponent: prepareFindSvelteComponent({
       ssrFolder: ssrComponents,
@@ -55,7 +55,7 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
     const cssFiles = fs.readdirSync(assetPath).filter((f) => f.endsWith('.css'));
     if (cssFiles.length > 1) {
       throw new Error(
-        `${config.$$internal.prefix} Race condition has caused multiple css files in ${assetPath}. If you keep seeing this delete the _elder and ___ELDER___  folders.`,
+        `${config.$$internal.logPrefix} Race condition has caused multiple css files in ${assetPath}. If you keep seeing this delete the _elder and ___ELDER___  folders.`,
       );
     }
     if (cssFiles[0]) {

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -21,7 +21,7 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
   const rootDir = config.rootDir === 'process.cwd()' ? process.cwd() : path.resolve(config.rootDir);
   config.rootDir = rootDir;
   config.srcDir = path.resolve(rootDir, `./${config.srcDir}`);
-  config.distDir = path.resolve(rootDir, path.join(`./${config.distDir}`, `${serverPrefix}`));
+  config.distDir = path.resolve(rootDir, `./${config.distDir}`);
 
   config.context = typeof initializationOptions.context !== 'undefined' ? initializationOptions.context : 'unknown';
   config.server = initializationOptions.context === 'server' && config.server;

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -17,7 +17,7 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
   }
   const config: SettingsOptions = defaultsDeep(initializationOptions, loadedConfig, getDefaultConfig());
 
-  const serverPrefix = normalizePrefix(loadedConfig.prefix || get(loadedConfig, 'server.prefix', ''));
+  const serverPrefix = normalizePrefix(config.prefix || get(config, 'server.prefix', ''));
 
   const rootDir = config.rootDir === 'process.cwd()' ? process.cwd() : path.resolve(config.rootDir);
   config.rootDir = rootDir;
@@ -28,6 +28,8 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
   config.server = initializationOptions.context === 'server' && config.server;
   config.build = initializationOptions.context === 'build' && config.build;
   config.worker = !!initializationOptions.worker;
+  config.prefix = serverPrefix;
+  config.server = serverPrefix ? { prefix: serverPrefix } : false;
 
   const ssrComponents = path.resolve(config.rootDir, './___ELDER___/compiled/');
   const clientComponents = path.resolve(config.distDir, `.${serverPrefix}/_elderjs/svelte/`);

--- a/src/utils/normalizePrefix.ts
+++ b/src/utils/normalizePrefix.ts
@@ -1,8 +1,8 @@
-const formatPrefix = (prefix: string) => {
+const normalizePrefix = (prefix: string) => {
   // remove trailing
   prefix.replace(/\/+$/, '');
 
   return prefix[0] === '/' ? prefix : `/${prefix}`;
 };
 
-export default formatPrefix;
+export default normalizePrefix;

--- a/src/utils/normalizePrefix.ts
+++ b/src/utils/normalizePrefix.ts
@@ -1,0 +1,8 @@
+const formatPrefix = (prefix: string) => {
+  // remove trailing
+  prefix.replace(/\/+$/, '');
+
+  return prefix[0] === '/' ? prefix : `/${prefix}`;
+};
+
+export default formatPrefix;

--- a/src/utils/normalizePrefix.ts
+++ b/src/utils/normalizePrefix.ts
@@ -1,7 +1,10 @@
 const normalizePrefix = (prefix: string) => {
-  // remove trailing
+  if (!prefix) return '';
+
+  // remove trailing slash
   prefix.replace(/\/+$/, '');
 
+  // add leading slash
   return prefix[0] === '/' ? prefix : `/${prefix}`;
 };
 

--- a/src/utils/normalizePrefix.ts
+++ b/src/utils/normalizePrefix.ts
@@ -2,10 +2,10 @@ const normalizePrefix = (prefix: string) => {
   if (!prefix) return '';
 
   // remove trailing slash
-  prefix.replace(/\/+$/, '');
+  const trimmed = prefix.replace(/\/+$/, '');
 
   // add leading slash
-  return prefix[0] === '/' ? prefix : `/${prefix}`;
+  return trimmed[0] === '/' ? trimmed : `/${trimmed}`;
 };
 
 export default normalizePrefix;

--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -1,3 +1,5 @@
+import get from 'lodash.get';
+
 /**
  * Helper function to allow permalinks to be referenced by obj.routeName.
  * It also handles adding of the /dev prefix when settings.server is true.
@@ -7,8 +9,10 @@
  */
 const permalinks = ({ routes, settings }) =>
   Object.keys(routes).reduce((out, cv) => {
+    const prefix = settings.prefix || get(settings, 'server.prefix', '');
+
     // eslint-disable-next-line no-param-reassign
-    out[cv] = (data) => `${routes[cv].permalink({ request: data, settings })}`;
+    out[cv] = (data) => `${prefix}${routes[cv].permalink({ request: data, settings })}`;
     return out;
   }, {});
 

--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -8,7 +8,7 @@
 const permalinks = ({ routes, settings }) =>
   Object.keys(routes).reduce((out, cv) => {
     // eslint-disable-next-line no-param-reassign
-    out[cv] = (data) => `${settings.$$internal.serverPrefix}${routes[cv].permalink({ request: data, settings })}`;
+    out[cv] = (data) => `${routes[cv].permalink({ request: data, settings })}`;
     return out;
   }, {});
 

--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -5,7 +5,7 @@ import get from 'lodash.get';
  * It also handles adding of the /dev prefix when settings.server is true.
  *
  * @param {Object} { routes, settings = {} }
- * @returns {Object} This object allows for referncing permalinks as obj.routeName()
+ * @returns {Object} This object allows for referencing permalinks as obj.routeName()
  */
 const permalinks = ({ routes, settings }) =>
   Object.keys(routes).reduce((out, cv) => {

--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -7,9 +7,8 @@
  */
 const permalinks = ({ routes, settings }) =>
   Object.keys(routes).reduce((out, cv) => {
-    const prefix = settings.server && settings.server.prefix ? settings.server.prefix : '';
     // eslint-disable-next-line no-param-reassign
-    out[cv] = (data) => `${prefix}${routes[cv].permalink({ request: data, settings })}`;
+    out[cv] = (data) => `${settings.$$internal.serverPrefix}${routes[cv].permalink({ request: data, settings })}`;
     return out;
   }, {});
 

--- a/src/utils/svelteComponent.ts
+++ b/src/utils/svelteComponent.ts
@@ -41,7 +41,7 @@ const svelteComponent = (componentName: String, folder: String = 'components') =
     return hydrateComponent({
       page,
       iife,
-      clientSrcMjs: `${page.settings.$$internal.serverPrefix}/${client}`,
+      clientSrcMjs: client,
       innerHtml: mountComponentsInHtml({ html: htmlOutput, page, hydrateOptions }),
       hydrateOptions,
       componentName: cleanComponentName,

--- a/src/utils/svelteComponent.ts
+++ b/src/utils/svelteComponent.ts
@@ -41,7 +41,7 @@ const svelteComponent = (componentName: String, folder: String = 'components') =
     return hydrateComponent({
       page,
       iife,
-      clientSrcMjs: client,
+      clientSrcMjs: `${page.settings.$$internal.serverPrefix}/${client}`,
       innerHtml: mountComponentsInHtml({ html: htmlOutput, page, hydrateOptions }),
       hydrateOptions,
       componentName: cleanComponentName,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -32,6 +32,7 @@ type Internal = {
   clientComponents: string;
   distElder: string;
   prefix: string;
+  serverPrefix: string;
   findComponent: FindSvelteComponent;
   publicCssFile?: string;
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -69,6 +69,7 @@ export type InitializationOptions = {
 };
 
 export type SettingsOptions = {
+  prefix: string;
   distDir: string;
   srcDir: string;
   rootDir: string;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -51,6 +51,7 @@ export type InitializationOptions = {
   srcDir?: string;
   rootDir?: string;
   origin?: string;
+  prefix?: string;
   lang?: string;
   server?: ServerOptions;
   build?: BuildOptions;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -31,7 +31,7 @@ type Internal = {
   ssrComponents: string;
   clientComponents: string;
   distElder: string;
-  prefix: string;
+  logPrefix: string;
   serverPrefix: string;
   findComponent: FindSvelteComponent;
   publicCssFile?: string;

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -73,8 +73,13 @@ const configSchema = yup.object({
       ),
   }),
   server: yup.object({
-    prefix: yup.string().notRequired().default('').label(`If Elder.js should serve all pages with a prefix.`),
+    prefix: yup
+      .string()
+      .notRequired()
+      .default('')
+      .label(`If Elder.js should serve all pages with a prefix. (deprecated)`),
   }),
+  prefix: yup.string().notRequired().default('').label(`If Elder.js should serve all pages with a prefix.`),
   build: yup.object({
     numberOfWorkers: yup
       .number()

--- a/src/utils/wrapPermalinkFn.ts
+++ b/src/utils/wrapPermalinkFn.ts
@@ -1,4 +1,4 @@
-import normalizePrefix from './normalizePrefix';
+import get from 'lodash.get';
 
 const wrapPermalinkFn = ({ permalinkFn, routeName, settings }) => (payload) => {
   let permalink = permalinkFn(payload);
@@ -56,7 +56,9 @@ const wrapPermalinkFn = ({ permalinkFn, routeName, settings }) => (payload) => {
     );
   }
 
-  return settings.$$internal.serverPrefix + permalink;
+  const prefix = get(settings, '$$internal.serverPrefix', '');
+
+  return prefix ? prefix + permalink : permalink;
 };
 
 export default wrapPermalinkFn;

--- a/src/utils/wrapPermalinkFn.ts
+++ b/src/utils/wrapPermalinkFn.ts
@@ -56,7 +56,7 @@ const wrapPermalinkFn = ({ permalinkFn, routeName, settings }) => (payload) => {
     );
   }
 
-  return `${settings.$$internal.prefix}${permalink}`;
+  return settings.$$internal.serverPrefix + permalink;
 };
 
 export default wrapPermalinkFn;

--- a/src/utils/wrapPermalinkFn.ts
+++ b/src/utils/wrapPermalinkFn.ts
@@ -1,3 +1,5 @@
+import normalizePrefix from './normalizePrefix';
+
 const wrapPermalinkFn = ({ permalinkFn, routeName, settings }) => (payload) => {
   let permalink = permalinkFn(payload);
 
@@ -54,7 +56,7 @@ const wrapPermalinkFn = ({ permalinkFn, routeName, settings }) => (payload) => {
     );
   }
 
-  return `${settings.prefix}${permalink}`;
+  return `${settings.$$internal.prefix}${permalink}`;
 };
 
 export default wrapPermalinkFn;

--- a/src/utils/wrapPermalinkFn.ts
+++ b/src/utils/wrapPermalinkFn.ts
@@ -54,7 +54,7 @@ const wrapPermalinkFn = ({ permalinkFn, routeName, settings }) => (payload) => {
     );
   }
 
-  return permalink;
+  return `${settings.prefix}${permalink}`;
 };
 
 export default wrapPermalinkFn;


### PR DESCRIPTION
Hi y'all

I came across this PR (https://github.com/Elderjs/elderjs/pull/126 - much appreciated @macabeus) and saw that list of TODOs that would need to be done before getting server prefixes to work properly.

Since we're having an actual business case that's currently blocked by this issue, I have the time to work on it frequently and would like to push it forward in this PR if that's ok?

Anyway, here is the stuff I've done so far:

### Updating the Config and Handling Legacy Definitions:

- [x] Move prefix out from within the server object and to it's own key on the root of the object within elder.config.js making the prefix accessible at (settings.prefix). This means updating validations.ts ... please note that validations.ts is used in building the documentation.

>  `settings.server.prefix` is now `settings.prefix`

- [x] Normalize the prefix to always be structured as /prefix/goes/here without the trailing slash as when combined with permalinks this should result in a fully qualified URL.

> created a new helper function for normalizing the prefix: `normalizePrefix.ts`

- [x] I believe the the clientComponents variable defined in getConfig.ts which is passed into prepareFindSvelteComponent will need to include the prefix as this controls where the svelte component files are written to. (We need to consider how windows relative file paths may not work correctly with \ and /. )

> added prefix to `clientComponents` path

- [x] Similarly to 3, distElder will need to include the prefix if present as this controls where lots of things are written to especially within rollupPlugin.ts where we are copying over files. (We need to consider how windows relative file paths may not work correctly with \ and /. )

> added prefix to `distElder` path

- [x] To prevent a breaking change, check for settings.server.prefix in getConfig.ts and if that key is found, set it to settings.prefix

> I've added some logic that will check for `settings.prefix`, if not set, check `settings.server.prefix` as a fallback – I hope this is what you meant here?

- [x] Update corresponding types to depreciate settings.server.prefix

> Added all the new types

- [x] Update config.$$internal.publicCssFile to include the prefix.

> Added server prefix to `config.$$internal.publicCssFile` in `getConfig.ts`

- [x] To avoid confusion we should rename the current config.$$internal.prefix which is used for console logging.

> Renamed `config.$$internal.prefix` to `config.$$internal.logPrefix`

### Implementing the Prefix Change

- [x] Once we have a new location where we know prefix will always be (settings.prefix), we should adjust wrapPermalinkFn to include the prefix so that the usual way of doing permalink within templates works. This allows for helpers.permalinks.blog({slug: "foo"}) to include the prefix automatically... This solves the issue shown in Elderjs/template#40 (review)

> Adjusted `wrapPermalinkFn.ts`

- [x] To avoid duplication of the prefix, we should edit permalinks.ts to remove the adding of prefix. (This was wedged in before I open sourced Elder.js).

> Removed the whole prefix logic there

- [x] To avoid duplication of the prefix, we should also remove lines 316-318 in Elder.ts because our update to the wrapPermalinkFn should handle this logic.

> Removed (I think you meant line 314-316?)

- [x] The hook elderExpressLikeMiddleware within hooks.ts will need to be updated to handle the new prefix location.

> Updated `elderExpressLikeMiddleware` to use `settings.$$internal.serverPrefix`

- [x] The hook elderAddDefaultIntersectionObserver within hooks.ts needs to be updated to handle the new prefix location.

> Updated `elderAddDefaultIntersectionObserver` to use the prefix

### Tests
This is quiet a large change so in addition to getting the current tests passing we should have tests that cover at a minimum:

- [x] Prefix beginning with a slash (getConfig.ts)
- [x] Prefix ending with a slash (getConfig.ts)
- [x] Prefix with both slash at beginning and end. (getConfig.ts)
- [x] No prefix (the default) (getConfig.ts)
- [x] Testing of the prefix and without a prefix (permalinks.ts)
- [x] Test to cover old settings.server.prefix usage. (getConfig.ts)
- [ ] Test to make sure that regardless of how the prefix is set that settings.$$internal.elderDir always works on windows and linux.
- [x] Test to ensure that the hook for `elderExpressLikeMiddleware` works with all variations of prefixes.
- [x] Test to ensure that the hook for `elderAddDefaultIntersectionObserver` works with all variations of prefixes.

----

As you can see I tried to implemented all the changes and it's working quite ok so far. For example I tested it with a `prefix: 'test'` and my build gives me something like this:

<details>
  <summary>Screenshot</summary>
  
  ![image](https://user-images.githubusercontent.com/5865010/106003162-37b53600-60b2-11eb-9e0c-e5ce5ae4948b.png)
</details>

Everthing neatly nested in `test` and path do resolve, which is already cool, but whats missing is the `_elderjs/static/intersection-observer.js` for some reason I don't know – could use some help on this one.

Other than that I already fixed some existing tests but haven't written any new ones yet. This is what I'm currently looking at.

Would love some feedback/input on this one @nickreese 

Thanks,
Christian

