### PR TITLE
Issue with double inline CSS for hydrated components

### DIFF
--- a/src/utils/__tests__/svelteComponent.spec.ts
+++ b/src/utils/__tests__/svelteComponent.spec.ts
@@ -202,10 +202,7 @@ describe('#svelteComponent', () => {
     expect(home(props)).toEqual(
       `<div class="svelte-datepicker"><div class="datepicker-component" id="datepickerSwrzsrVDCd"><div>DATEPICKER</div></div></div>`,
     );
-    expect(props.page.svelteCss).toEqual([
-      { css: ['<css>', '<css2>'], cssMap: ['<cssmap>', '<cssmap2>'] },
-      { css: ['<css3>'], cssMap: ['<cssmap3>'] },
-    ]);
+    expect(props.page.svelteCss).toEqual([{ css: ['<css>', '<css2>'], cssMap: ['<cssmap>', '<cssmap2>'] }]);
   });
 
   it('svelteComponent respects css settings: file', () => {

--- a/src/utils/svelteComponent.ts
+++ b/src/utils/svelteComponent.ts
@@ -29,7 +29,7 @@ const svelteComponent = (componentName: String, folder: String = 'components') =
     const { html: htmlOutput, head } = render(props);
 
     if (page.settings.css === 'inline') {
-      if (css && css.length > 0 && page.svelteCss) {
+      if (css && css.length > 0 && page.svelteCss && !hydrateOptions) {
         page.svelteCss.push({ css, cssMap });
       }
     }


### PR DESCRIPTION
I am experiencing an issue with CSS appearing twice when inlined for hydrated components.

Steps to reproduce:
1. Start a fresh template project. Change the CSS setting to `css: 'inline'`
2. Build rollup and start the server
3. Visit the start page and view the source. You will for instance see the following CSS appear twice: `.clock-face.svelte-1mtan91` for the clock.
4. Now link this branch of ElderJS. Now the CSS above will only appear once.

The change I have done is that we are not pushing CSS when the setting is inline and it is a hydrated component. This since the CSS will appear both in the compiled route file as well as in the compiled component file, but we only need it once.
