### PR TITLE
[draft]Plugin: add minimalElder field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elderjs/elderjs",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7455,6 +7455,14 @@
       "integrity": "sha1-eB4YMpaqlPbU2RbcM10NF676I/g=",
       "dev": true
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -8879,10 +8887,12 @@
       }
     },
     "semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-      "dev": true
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "serialize-javascript": {
       "version": "4.0.0",
@@ -10120,6 +10130,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
       "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-multi-input": "^1.2.0",
     "rollup-plugin-terser": "^7.0.2",
+    "semver": "^7.3.4",
     "spark-md5": "^3.0.1",
     "svelte": "3.35.0",
     "yup": "^0.29.3"

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -142,6 +142,7 @@ interface Init {
 export type PluginOptions = {
   name: string;
   description: string;
+  minimalElder: string;
   init: Init | any;
   routes?: RoutesOptions;
   hooks: Array<HookOptions>;

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -172,6 +172,7 @@ const pluginSchema = yup.object({
       'Init should be a function or async function',
       (value) => typeof value === 'function' || (typeof value === 'object' && value.then === 'function'),
     ),
+  minimalElder: yup.string().default('1.0.0').label('Minimal Elderjs version compatibility.'),
   routes: yup.object().notRequired().default({}).label('(optional) Any routes the plugin is adding.'),
   hooks: yup.array().required().default([]).label('An array of hooks.'),
   config: yup


### PR DESCRIPTION
Add `minimalElder` fields for plugins, using `semver`package to check version compatibility.

Verification is done before plugin `init` call because we don't want to initialise the plugin if it's not compatible with the current elderjs version.

 As the schema validation is done after plugin `initialisation`, which allows the plugins to add dynamicly required fields, the verification of the versions compatibility is done outside this context.

- [x] implementation
- [ ] test

Fixed: https://github.com/Elderjs/elderjs/issues/123