### PR TITLE
Feat: Exposes a method to add routes after initialisation

### DIFF
--- a/src/Elder.ts
+++ b/src/Elder.ts
@@ -333,6 +333,10 @@ class Elder {
   worker(workerRequests) {
     return workerBuild({ bootstrapComplete: this.bootstrapComplete, workerRequests });
   }
+
+  addRoute(routeObject) {
+    this.serverLookupObject[routeObject.permalink] = routeObject;
+  }
 }
 
 export { Elder, build, partialHydration };


### PR DESCRIPTION
I would like some feedback on the following feature:

We would like to be able to add static routes after initialisation of the Elder server.
The idea is to be able to listen to requests or pubsubs and call the addroute method to make those pages available without having to restart the service.

Example usage:
```
  elder = new Elder({ context: 'server' });
  const { distDir } = getConfig();
  server.use(elder.server);
  server.use(sirv(distDir, { dev: true }));

  const newRoute = {
    slug: 'newlyadded',
    route: 'start_page',
    type: 'server',
    permalink: '/newlyadded',
  };
  setTimeout(() => elder.addRoute(newRoute), 3000);
  
  ```