### PR TITLE
Improved partial hydration code

### DIFF
--- a/src/partialHydration/__tests__/hydrateComponents.spec.ts
+++ b/src/partialHydration/__tests__/hydrateComponents.spec.ts
@@ -173,6 +173,62 @@ describe('#hydrateComponents', () => {
           source: 'autocompleteZlwFFdKTtG',
           string: '<link rel="preload" href="/props/ejs--389426143.js" as="script">',
         },
+        {
+          priority: 50,
+          source: 'zoomablemapgYtFjVCDSS',
+          string:
+            '<link rel="prefetch" href="/_elderjs/svelte/components/ZoomableMap/ZoomableMap.AOMHQNYN.js" as="script">',
+        },
+        {
+          priority: 49,
+          source: 'zoomablemapgYtFjVCDSS',
+          string: '<link rel="prefetch" href="/props/ejs-1585068398.js" as="script">',
+        },
+        {
+          priority: 50,
+          source: 'headerzbmmDtJVlq',
+          string: '<link rel="prefetch" href="/_elderjs/svelte/components/Header/Header.AOWJN766.js" as="script">',
+        },
+        {
+          priority: 49,
+          source: 'headerzbmmDtJVlq',
+          string: '<link rel="prefetch" href="/props/ejs--453144257.js" as="script">',
+        },
+      ]);
+    });
+
+    test('prefetch override with external prop file', async () => {
+      const page = JSON.parse(JSON.stringify(defaultPage));
+      page.settings.props.hydration = 'file';
+      page.componentsToHydrate = JSON.parse(JSON.stringify(defaultComponents));
+      page.componentsToHydrate[0].hydrateOptions.noPrefetch = true;
+
+      const reqHydrateComponents = require('../hydrateComponents');
+
+      await reqHydrateComponents.default(page);
+
+      expect(page.headStack).toMatchObject([
+        {
+          priority: 50,
+          source: 'zoomablemapgYtFjVCDSS',
+          string:
+            '<link rel="prefetch" href="/_elderjs/svelte/components/ZoomableMap/ZoomableMap.AOMHQNYN.js" as="script">',
+        },
+        {
+          priority: 49,
+          source: 'zoomablemapgYtFjVCDSS',
+          string: '<link rel="prefetch" href="/props/ejs-1585068398.js" as="script">',
+        },
+        {
+          priority: 50,
+          source: 'headerzbmmDtJVlq',
+          string: '<link rel="prefetch" href="/_elderjs/svelte/components/Header/Header.AOWJN766.js" as="script">',
+        },
+        {
+          priority: 49,
+          source: 'headerzbmmDtJVlq',
+          string: '<link rel="prefetch" href="/props/ejs--453144257.js" as="script">',
+        },
       ]);
     });
   });

--- a/src/partialHydration/__tests__/hydrateComponents.spec.ts
+++ b/src/partialHydration/__tests__/hydrateComponents.spec.ts
@@ -134,7 +134,7 @@ describe('#hydrateComponents', () => {
 
       await reqHydrateComponents.default(page);
 
-      expect(page.componentsToHydrate[0].prepared.clientPropsUrl).toEqual('/props/ejs-2086035908.js');
+      expect(page.componentsToHydrate[0].prepared.clientPropsUrl).toEqual('/props/ejs-2086035908.json');
       expect(counts).toMatchObject({ existsSync: 3, mkdirSync: 0, writeFile: 1 });
     });
 
@@ -148,7 +148,7 @@ describe('#hydrateComponents', () => {
 
       await reqHydrateComponents.default(page);
 
-      expect(page.componentsToHydrate[0].prepared.clientPropsUrl).toEqual('/props/ejs-1363984429.js');
+      expect(page.componentsToHydrate[0].prepared.clientPropsUrl).toEqual('/props/ejs-1363984429.json');
     });
 
     test('preloads with external prop file', async () => {
@@ -171,7 +171,7 @@ describe('#hydrateComponents', () => {
         {
           priority: 49,
           source: 'autocompleteZlwFFdKTtG',
-          string: '<link rel="preload" href="/props/ejs--389426143.js" as="script">',
+          string: '<link rel="preload" href="/props/ejs--389426143.json" as="fetch">',
         },
         {
           priority: 50,
@@ -182,7 +182,7 @@ describe('#hydrateComponents', () => {
         {
           priority: 49,
           source: 'zoomablemapgYtFjVCDSS',
-          string: '<link rel="prefetch" href="/props/ejs-1585068398.js" as="script">',
+          string: '<link rel="prefetch" href="/props/ejs-1585068398.json" as="fetch">',
         },
         {
           priority: 50,
@@ -192,7 +192,7 @@ describe('#hydrateComponents', () => {
         {
           priority: 49,
           source: 'headerzbmmDtJVlq',
-          string: '<link rel="prefetch" href="/props/ejs--453144257.js" as="script">',
+          string: '<link rel="prefetch" href="/props/ejs--453144257.json" as="fetch">',
         },
       ]);
     });
@@ -217,7 +217,7 @@ describe('#hydrateComponents', () => {
         {
           priority: 49,
           source: 'zoomablemapgYtFjVCDSS',
-          string: '<link rel="prefetch" href="/props/ejs-1585068398.js" as="script">',
+          string: '<link rel="prefetch" href="/props/ejs-1585068398.json" as="fetch">',
         },
         {
           priority: 50,
@@ -227,7 +227,7 @@ describe('#hydrateComponents', () => {
         {
           priority: 49,
           source: 'headerzbmmDtJVlq',
-          string: '<link rel="prefetch" href="/props/ejs--453144257.js" as="script">',
+          string: '<link rel="prefetch" href="/props/ejs--453144257.json" as="fetch">',
         },
       ]);
     });

--- a/src/partialHydration/hydrateComponents.ts
+++ b/src/partialHydration/hydrateComponents.ts
@@ -197,6 +197,21 @@ export default (page: Page) => {
           // string: `<link rel="modulepreload" href="${clientSrcMjs}">`, <-- can be an option for Chrome if browsers don't like this.
         });
       }
+    } else if (!component.hydrateOptions.noPrefetch) {
+      page.headStack.push({
+        source: component.name,
+        priority: 50,
+        string: `<link rel="prefetch" href="${component.client}" as="script">`,
+        // string: `<link rel="modulepreload" href="${clientSrcMjs}">`, <-- can be an option for Chrome if browsers don't like this.
+      });
+      if (component.prepared.clientPropsUrl) {
+        page.headStack.push({
+          source: component.name,
+          priority: 49,
+          string: `<link rel="prefetch" href="${component.prepared.clientPropsUrl}" as="script">`,
+          // string: `<link rel="modulepreload" href="${clientSrcMjs}">`, <-- can be an option for Chrome if browsers don't like this.
+        });
+      }
     }
   }
 

--- a/src/partialHydration/hydrateComponents.ts
+++ b/src/partialHydration/hydrateComponents.ts
@@ -7,7 +7,7 @@ import windowsPathFix from '../utils/windowsPathFix';
 
 const defaultElderHelpers = (decompressCode, prefix) => `
 let IO, $$COMPONENTS={};
-const $$ejs = async (arr)=>{
+const $$ejs = (arr)=>{
   ${decompressCode}
   const prefix = '${prefix}';
 
@@ -19,8 +19,7 @@ const $$ejs = async (arr)=>{
     };
 
     if(typeof  $$COMPONENTS[arr[i][0]].props === 'string'){
-      const propsFile = await import(prefix+'/props/'+$$COMPONENTS[arr[i][0]].props);
-      $$COMPONENTS[arr[i][0]].props = $ejs(propsFile.default);
+      $$COMPONENTS[arr[i][0]].props = import(prefix+'/props/'+$$COMPONENTS[arr[i][0]].props);
     };
 
     if (!IO) {
@@ -29,10 +28,10 @@ const $$ejs = async (arr)=>{
           if (entry.isIntersecting) {
             const selected = $$COMPONENTS[entry.target.id];
             observer.unobserve(selected.elem);
-            import(prefix + '/svelte/components/' + selected.component).then((comp)=>{
+            import(prefix + '/svelte/components/' + selected.component).then(async (comp)=>{
                 new comp.default({ 
                   target: selected.elem,
-                  props: selected.props,
+                  props: selected.props && typeof selected.props.then == "function" ? $ejs(await (selected.props).default) : selected.props,
                   hydrate: true
                 });
             });

--- a/src/partialHydration/hydrateComponents.ts
+++ b/src/partialHydration/hydrateComponents.ts
@@ -149,13 +149,19 @@ export default (page: Page) => {
     }
 
     if (component.hydrateOptions.loading === 'eager') {
-      eagerString += `'${component.name}' : { 'component' : '${component.client.replace(`${relPrefix}/svelte/components/`, '')}', 'props' : ${
+      eagerString += `'${component.name}' : { 'component' : '${component.client.replace(
+        `${relPrefix}/svelte/components/`,
+        '',
+      )}', 'props' : ${
         component.prepared.clientPropsUrl
           ? `'${component.prepared.clientPropsUrl.replace(`${relPrefix}/props/`, '')}'`
           : component.prepared.clientPropsString
       }},`;
     } else {
-      deferString += `'${component.name}' : { 'component' : '${component.client.replace(`${relPrefix}/svelte/components/`, '')}', 'props' : ${
+      deferString += `'${component.name}' : { 'component' : '${component.client.replace(
+        `${relPrefix}/svelte/components/`,
+        '',
+      )}', 'props' : ${
         component.prepared.clientPropsUrl
           ? `'${component.prepared.clientPropsUrl.replace(`${relPrefix}/props/`, '')}'`
           : component.prepared.clientPropsString

--- a/src/partialHydration/hydrateComponents.ts
+++ b/src/partialHydration/hydrateComponents.ts
@@ -13,7 +13,6 @@ const $$ejs = (arr)=>{
 
   for (let i = 0; i < arr.length; i++) {
     $$COMPONENTS[arr[i][0]] = {
-      elem: document.getElementById(arr[i][0]),
       component: arr[i][1],
       props: $ejs(arr[i][2]) || {},
     };
@@ -27,10 +26,10 @@ const $$ejs = (arr)=>{
         entires.forEach(entry => {
           if (entry.isIntersecting) {
             const selected = $$COMPONENTS[entry.target.id];
-            observer.unobserve(selected.elem);
+            observer.unobserve(entry.target);
             import(prefix + '/svelte/components/' + selected.component).then(async (comp)=>{
                 new comp.default({ 
-                  target: selected.elem,
+                  target: entry.target,
                   props: selected.props && typeof selected.props.then == "function" ? $ejs(await (selected.props).default) : selected.props,
                   hydrate: true
                 });
@@ -39,7 +38,7 @@ const $$ejs = (arr)=>{
         });
       });
     };
-    IO.observe($$COMPONENTS[arr[i][0]].elem);
+    IO.observe(document.getElementById(arr[i][0]));
   }
 };
 `;

--- a/src/partialHydration/hydrateComponents.ts
+++ b/src/partialHydration/hydrateComponents.ts
@@ -9,12 +9,11 @@ const defaultElderHelpers = (decompressCode, prefix, generateLazy) => `
 const $$ejs = (par,eager)=>{
   ${decompressCode}
   const prefix = '${prefix}';
-  const initComponent = (component,target, props) => {
-    const propProm = ((typeof props === 'string') ? import(prefix+'/props/'+ props).then(r => r.default) : new Promise((resolve) => resolve(props))).then( props => $ejs(props) );
-    Promise.all([propProm,import(prefix + '/svelte/components/' + component)]).then(([props,comp])=>{
+  const initComponent = (component,target, props, prom) => {
+    import(prefix + '/svelte/components/' + component).then(async (comp)=>{
       new comp.default({ 
         target: target,
-        props: props,
+        props: $ejs(prom ? (await prom).default : props),
         hydrate: true
       });
     });
@@ -26,18 +25,21 @@ const $$ejs = (par,eager)=>{
       if (entry.isIntersecting) {
         observer.unobserve(entry.target);
         const selected = par[entry.target.id];
-        initComponent(selected.component,entry.target,selected.props)
+        initComponent(selected.component,entry.target,selected.props,selected.promise)
       }
     });
   });`
       : ''
   }
   Object.entries(par).forEach(([k,v]) => {
+    if(typeof v.props === 'string'){
+      par[k].promise = import(prefix+'/props/'+v.props)
+    };
     const el = document.getElementById(k);
     if (${generateLazy ? '!eager' : 'false'}) {
         IO.observe(el);
     } else {
-        initComponent(v.component,el,v.props);
+        initComponent(v.component,el,v.props,v.promise);
     }
   });
 };

--- a/src/partialHydration/hydrateComponents.ts
+++ b/src/partialHydration/hydrateComponents.ts
@@ -25,11 +25,7 @@ const $$ejs = async (arr)=>{
 
     if (!IO) {
       IO = new IntersectionObserver((entries, observer) => {
-        var objK = Object.keys(entries);
-        var objKl = objK.length;
-        var objKi = 0;
-        for (; objKi < objKl; objKi++) {
-          const entry = entries[objK[objKi]];
+        entires.forEach(entry => {
           if (entry.isIntersecting) {
             const selected = $$COMPONENTS[entry.target.id];
             observer.unobserve(selected.elem);
@@ -41,7 +37,7 @@ const $$ejs = async (arr)=>{
                 });
             });
           }
-        }
+        });
       });
     };
     IO.observe($$COMPONENTS[arr[i][0]].elem);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -170,6 +170,7 @@ export type ExcludesFalse = <T>(x: T | false) => x is T;
 export type HydrateOptions = {
   loading?: 'lazy' | 'eager' | 'none';
   preload?: boolean;
+  noPrefetch?: boolean;
   threshold?: number;
   rootMargin?: string;
 };


### PR DESCRIPTION
This PR improves the partial hydration code sent to the client. They mostly aim at reducing code size, but 272b131 should improve concurrency in loading props. 

There are 4 commits in this pull requests with increasing "aggressiveness" in changing the current implementation.  Feel free to only pick a subset if you disagree with my suggestions.

I haven't tested against real compressed props, as i currently have no data that seems to trigger it. But everything is passed transparently through the $ejs function.  Could you confirm this works ok and then update the snapshot tests? (Or let me know and i will revise this PR)