### PR TITLE
Remove and/or use local polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
   "files": [
     "build/**/*"
   ],
-  "peerDependencies": {
-    "intersection-observer": "^0.12.0"
-  },
   "dependencies": {
     "@babel/core": "^7.13.10",
     "@elderjs/shortcodes": "^1.0.7",

--- a/src/__tests__/__snapshots__/Elder.spec.ts.snap
+++ b/src/__tests__/__snapshots__/Elder.spec.ts.snap
@@ -278,7 +278,7 @@ Object {
           <ul>
             <li><strong>headStack:</strong> Internally all content used in <svelte:head></svelte:head> are added to the head stack. If you were looking to add ld+json to the page, you could do it here. If you're looking to write &lt;title&gt; tags, we recommend doing it within Svelte templates unless you are writing a plugin in which case you may want to also look at the 'head' hook.</li>
             <li><strong>cssStack:</strong> The 'cssStack' represents all of the css strings added by hooks and plugins. Plugins can add css here (our in the head stack if you need to add CSS before the Elder.js CSS file), but we recommend users add them directly in Svelte files. Note: Do not wrap strings added to the stack in &lt;style&gt;&lt;/style&gt;.</li>
-            <li><strong>beforeHydrateStack:</strong> default this stack includes a polyfill for intersection observer. This stack is not run unless there are Svelte components to be hydrated. </li>
+            <li><strong>beforeHydrateStack:</strong> Polyfills for hydration could be added here. This stack is not run unless there are Svelte components to be hydrated. </li>
             <li><strong>hydrateStack:</strong> the hydrateStack contains strings which represent all of the root svelte components which will be hydrated.</li>
             <li><strong>customJsStack:</strong> Used to add custom JS to the site. This is done after the Svelte components are written to the page. </li>
             <li><strong>footerStack:</strong> the footerStack which is an array of html or html friendly strings that will be written to the footer. This is generally the ideal place for plugins to add Analytics scripts as it fires after all other JS.</li>
@@ -487,17 +487,6 @@ Object {
       "description": "Adds the css found in the svelte files to the head if 'css' in your 'elder.config.js' file is set to 'file'.",
       "hook": "stacks",
       "name": "elderAddCssFileToHead",
-      "priority": 100,
-      "run": [Function],
-    },
-    Object {
-      "$$meta": Object {
-        "addedBy": "elder.js",
-        "type": "internal",
-      },
-      "description": "Sets up the default polyfill for the intersection observer and request idle callback.",
-      "hook": "stacks",
-      "name": "elderAddDefaultIntersectionObserver",
       "priority": 100,
       "run": [Function],
     },
@@ -931,7 +920,7 @@ Object {
           <ul>
             <li><strong>headStack:</strong> Internally all content used in <svelte:head></svelte:head> are added to the head stack. If you were looking to add ld+json to the page, you could do it here. If you're looking to write &lt;title&gt; tags, we recommend doing it within Svelte templates unless you are writing a plugin in which case you may want to also look at the 'head' hook.</li>
             <li><strong>cssStack:</strong> The 'cssStack' represents all of the css strings added by hooks and plugins. Plugins can add css here (our in the head stack if you need to add CSS before the Elder.js CSS file), but we recommend users add them directly in Svelte files. Note: Do not wrap strings added to the stack in &lt;style&gt;&lt;/style&gt;.</li>
-            <li><strong>beforeHydrateStack:</strong> default this stack includes a polyfill for intersection observer. This stack is not run unless there are Svelte components to be hydrated. </li>
+            <li><strong>beforeHydrateStack:</strong> Polyfills for hydration could be added here. This stack is not run unless there are Svelte components to be hydrated. </li>
             <li><strong>hydrateStack:</strong> the hydrateStack contains strings which represent all of the root svelte components which will be hydrated.</li>
             <li><strong>customJsStack:</strong> Used to add custom JS to the site. This is done after the Svelte components are written to the page. </li>
             <li><strong>footerStack:</strong> the footerStack which is an array of html or html friendly strings that will be written to the footer. This is generally the ideal place for plugins to add Analytics scripts as it fires after all other JS.</li>
@@ -1140,17 +1129,6 @@ Object {
       "description": "Adds the css found in the svelte files to the head if 'css' in your 'elder.config.js' file is set to 'file'.",
       "hook": "stacks",
       "name": "elderAddCssFileToHead",
-      "priority": 100,
-      "run": [Function],
-    },
-    Object {
-      "$$meta": Object {
-        "addedBy": "elder.js",
-        "type": "internal",
-      },
-      "description": "Sets up the default polyfill for the intersection observer and request idle callback.",
-      "hook": "stacks",
-      "name": "elderAddDefaultIntersectionObserver",
       "priority": 100,
       "run": [Function],
     },

--- a/src/esbuild/esbuildBundler.ts
+++ b/src/esbuild/esbuildBundler.ts
@@ -207,21 +207,6 @@ const esbuildBundler = async ({ initializationOptions = {}, replacements = {} }:
 
     const restartHelper = getRestartHelper(startOrRestartServer);
 
-    if (!fs.existsSync(path.resolve('./node_modules/intersection-observer/intersection-observer.js'))) {
-      throw new Error(`Missing 'intersection-observer' dependency. Run 'npm i --save intersection-observer' to fix.`);
-    }
-
-    buildSync({
-      format: 'iife',
-      minify: true,
-      watch: false,
-      outfile: path.resolve(
-        elderConfig.prefix ? path.join(elderConfig.distDir, elderConfig.prefix) : elderConfig.distDir,
-        `./static/intersection-observer.js`,
-      ),
-      entryPoints: [path.resolve('./node_modules/intersection-observer/intersection-observer.js')],
-    });
-
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const restartEsbuild = await svelteHandler({
       elderConfig,

--- a/src/esbuild/esbuildBundler.ts
+++ b/src/esbuild/esbuildBundler.ts
@@ -5,7 +5,7 @@
 // reload can also be called after esbuild finishes the rebuild.
 // the file watcher should restart the entire esbuild process when a new svelte file is seen. This includes clearing caches.
 
-import { build, BuildResult, buildSync } from 'esbuild';
+import { build, BuildResult } from 'esbuild';
 import glob from 'glob';
 import path from 'path';
 

--- a/src/hooks/__tests__/__snapshots__/hooks.spec.ts.snap
+++ b/src/hooks/__tests__/__snapshots__/hooks.spec.ts.snap
@@ -1,36 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#hooks elderAddDefaultIntersectionObserver 1`] = `
-Object {
-  "beforeHydrateStack": Array [
-    Object {
-      "priority": 100,
-      "source": "elderAddDefaultIntersectionObserver",
-      "string": "<script type=\\"text/javascript\\">
-            var requestIdleCallback = window.requestIdleCallback ||
-            function (cb) {
-              var s = Date.now();
-              return setTimeout(function () {
-                cb({
-                  didTimeout: false,
-                  timeRemaining: function () {
-                    return Math.max(0, 50 - (Date.now() - s));
-                  },
-                });
-              }, 1);
-            };
-            if (!('IntersectionObserver' in window)) {
-                var script = document.createElement(\\"script\\");
-                script.src = \\"/_elderjs/static/intersection-observer.js\\";
-                document.getElementsByTagName('head')[0].appendChild(script);
-            };
-      </script>
-      ",
-    },
-  ],
-}
-`;
-
 exports[`#hooks elderAddExternalHelpers 1`] = `
 Object {
   "helpers": Object {
@@ -105,13 +74,6 @@ Array [
     "description": "Adds the css found in the svelte files to the head if 'css' in your 'elder.config.js' file is set to 'file'.",
     "hook": "stacks",
     "name": "elderAddCssFileToHead",
-    "priority": 100,
-    "run": [Function],
-  },
-  Object {
-    "description": "Sets up the default polyfill for the intersection observer and request idle callback.",
-    "hook": "stacks",
-    "name": "elderAddDefaultIntersectionObserver",
     "priority": 100,
     "run": [Function],
   },

--- a/src/hooks/__tests__/hooks.spec.ts
+++ b/src/hooks/__tests__/hooks.spec.ts
@@ -76,20 +76,6 @@ describe('#hooks', () => {
     const hook = hooks.find((h) => h.name === 'elderAddMetaViewportToHead');
     expect(normalizeSnapshot(await hook.run({ headStack: [] }))).toMatchSnapshot();
   });
-  it('elderAddDefaultIntersectionObserver', async () => {
-    const hook = hooks.find((h) => h.name === 'elderAddDefaultIntersectionObserver');
-    expect(normalizeSnapshot(await hook.run({ beforeHydrateStack: [] }))).toMatchSnapshot();
-  });
-  it('elderAddDefaultIntersectionObserver with prefix', async () => {
-    const hook = hooks.find((h) => h.name === 'elderAddDefaultIntersectionObserver');
-    const settings = {
-      $$internal: {
-        serverPrefix: '/dev',
-      },
-    };
-    const result = await hook.run({ beforeHydrateStack: [], settings });
-    expect(result.beforeHydrateStack[0].string).toContain('/dev/_elderjs/static/intersection-observer.js');
-  });
   it('elderCompileHtml', async () => {
     const hook = hooks.find((h) => h.name === 'elderCompileHtml');
     expect(

--- a/src/hooks/hookInterface.ts
+++ b/src/hooks/hookInterface.ts
@@ -217,7 +217,7 @@ export const hookInterface: Array<HookInterface> = [
           <ul>
             <li><strong>headStack:</strong> Internally all content used in <svelte:head></svelte:head> are added to the head stack. If you were looking to add ld+json to the page, you could do it here. If you're looking to write &lt;title&gt; tags, we recommend doing it within Svelte templates unless you are writing a plugin in which case you may want to also look at the 'head' hook.</li>
             <li><strong>cssStack:</strong> The 'cssStack' represents all of the css strings added by hooks and plugins. Plugins can add css here (our in the head stack if you need to add CSS before the Elder.js CSS file), but we recommend users add them directly in Svelte files. Note: Do not wrap strings added to the stack in &lt;style&gt;&lt;/style&gt;.</li>
-            <li><strong>beforeHydrateStack:</strong> default this stack includes a polyfill for intersection observer. This stack is not run unless there are Svelte components to be hydrated. </li>
+            <li><strong>beforeHydrateStack:</strong> Polyfills for hydration could be added here. This stack is not run unless there are Svelte components to be hydrated. </li>
             <li><strong>hydrateStack:</strong> the hydrateStack contains strings which represent all of the root svelte components which will be hydrated.</li>
             <li><strong>customJsStack:</strong> Used to add custom JS to the site. This is done after the Svelte components are written to the page. </li>
             <li><strong>footerStack:</strong> the footerStack which is an array of html or html friendly strings that will be written to the footer. This is generally the ideal place for plugins to add Analytics scripts as it fires after all other JS.</li>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,7 +1,6 @@
 /* eslint-disable consistent-return */
 import path from 'path';
 import fs from 'fs-extra';
-import get from 'lodash.get';
 import { parseBuildPerf } from '../utils';
 import externalHelpers from '../externalHelpers';
 import { HookOptions } from './types';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -150,45 +150,6 @@ const hooks: Array<HookOptions> = [
     },
   },
   {
-    hook: 'stacks',
-    name: 'elderAddDefaultIntersectionObserver',
-    description: 'Sets up the default polyfill for the intersection observer and request idle callback.',
-    priority: 100,
-    run: async ({ beforeHydrateStack, settings }) => {
-      const prefix = get(settings, '$$internal.serverPrefix', '');
-
-      return {
-        beforeHydrateStack: [
-          {
-            source: 'elderAddDefaultIntersectionObserver',
-            string: `<script type="text/javascript">
-            var requestIdleCallback = window.requestIdleCallback ||
-            function (cb) {
-              var s = Date.now();
-              return setTimeout(function () {
-                cb({
-                  didTimeout: false,
-                  timeRemaining: function () {
-                    return Math.max(0, 50 - (Date.now() - s));
-                  },
-                });
-              }, 1);
-            };
-            if (!('IntersectionObserver' in window)) {
-                var script = document.createElement("script");
-                script.src = "${prefix}/_elderjs/static/intersection-observer.js";
-                document.getElementsByTagName('head')[0].appendChild(script);
-            };
-      </script>
-      `,
-            priority: 100,
-          },
-          ...beforeHydrateStack,
-        ],
-      };
-    },
-  },
-  {
     hook: 'compileHtml',
     name: 'elderCompileHtml',
     description: 'Creates an HTML string out of the Svelte layout and stacks.',

--- a/src/partialHydration/hydrateComponents.ts
+++ b/src/partialHydration/hydrateComponents.ts
@@ -219,6 +219,12 @@ export default (page: Page) => {
       source: 'hydrateComponents',
       priority: 30,
       string: `<script type="module">
+            const requestIdleCallback = window.requestIdleCallback || ( cb => window.setTimeout(cb,1) );
+            if (!('IntersectionObserver' in window)) {
+                const script = document.createElement("script");
+                script.src = "${page.settings.$$internal.serverPrefix}/_elderjs/static/intersection-observer.js";
+                document.getElementsByTagName('head')[0].appendChild(script);
+            };
       ${defaultElderHelpers(decompressCode, relPrefix, deferString.length > 0)}
       ${eagerString.length > 0 ? `$$ejs({${eagerString}},true)` : ''}${
         deferString.length > 0

--- a/src/partialHydration/hydrateComponents.ts
+++ b/src/partialHydration/hydrateComponents.ts
@@ -24,20 +24,20 @@ const $$ejs = (par,eager)=>{
   };
   ${
     generateLazy
-      ? `const IO = new IntersectionObserver((entries, observer) => {
-              entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                  observer.unobserve(entry.target);
-                  const selected = par[entry.target.id];
-                  initComponent(entry.target,selected);
-                }
-              });
-          }, { rootMargin: "200px",threshold: 0});`
+      ? `const IO = ('IntersectionObserver' in window) ? new IntersectionObserver((entries, observer) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        observer.unobserve(entry.target);
+        const selected = par[entry.target.id];
+        initComponent(entry.target,selected)
+      }
+    });
+  }, { rootMargin: "200px",threshold: 0}) : undefined;`
       : ''
   }
   Object.keys(par).forEach(k => {
     const el = document.getElementById(k);
-    if (${generateLazy ? '!eager' : 'false'}) {
+    if (${generateLazy ? '!eager && IO' : 'false'}) {
         IO.observe(el);
     } else {
         initComponent(el,par[k]);
@@ -220,11 +220,6 @@ export default (page: Page) => {
       priority: 30,
       string: `<script type="module">
             const requestIdleCallback = window.requestIdleCallback || ( cb => window.setTimeout(cb,1) );
-            if (!('IntersectionObserver' in window)) {
-                const script = document.createElement("script");
-                script.src = "${page.settings.$$internal.serverPrefix}/_elderjs/static/intersection-observer.js";
-                document.getElementsByTagName('head')[0].appendChild(script);
-            };
       ${defaultElderHelpers(decompressCode, relPrefix, deferString.length > 0)}
       ${eagerString.length > 0 ? `$$ejs({${eagerString}},true)` : ''}${
         deferString.length > 0

--- a/src/rollup/__tests__/getRollupConfig.spec.ts
+++ b/src/rollup/__tests__/getRollupConfig.spec.ts
@@ -158,31 +158,6 @@ describe('#getRollupConfig', () => {
     ).toEqual(['replace', 'json', 'rollup-plugin-elder', 'node-resolve', 'commonjs', 'terser']);
   });
 
-  it('getRollupConfig - throws error if intersection-observer doesnt exist', () => {
-    jest.mock('../../utils/validations.ts', () => ({
-      getDefaultRollup: () => ({}),
-    }));
-
-    jest.mock('del');
-    // getElderConfig() mock
-    jest.mock('../../utils/getConfig', () => () => ({
-      $$internal: {
-        clientComponents: 'test/public/svelte',
-        ssrComponents: 'test/___ELDER___/compiled',
-      },
-      distDir: './dist',
-      srcDir: './src',
-      rootDir: './',
-      plugins: {},
-    }));
-    jest.mock('fs-extra', () => ({
-      existsSync: jest.fn().mockImplementationOnce(() => false),
-    }));
-    expect(() => require('../getRollupConfig').default()).toThrow(
-      `Elder.js peer dependency not found at ./node_modules/intersection-observer/intersection-observer.js`,
-    );
-  });
-
   it('getRollupConfig as a whole works - default options', () => {
     jest.mock('../../utils/validations.ts', () => ({
       getDefaultRollup: () => ({

--- a/src/rollup/__tests__/getRollupConfig.spec.ts
+++ b/src/rollup/__tests__/getRollupConfig.spec.ts
@@ -6,12 +6,6 @@ import getConfig from '../../utils/getConfig';
 
 // TODO: test replace
 
-const fixRelativePath = (arr) => {
-  // eslint-disable-next-line no-param-reassign
-  arr[0].output[0].file = arr[0].output[0].file.replace(process.cwd(), '');
-  return arr;
-};
-
 jest.mock('fs-extra', () => {
   return {
     ensureDirSync: () => {},
@@ -204,7 +198,7 @@ describe('#getRollupConfig', () => {
     };
 
     // would be nice to mock getPluginPaths if it's extracted to separate file
-    const configs = fixRelativePath(require('../getRollupConfig').default({ svelteConfig }));
-    expect(configs).toHaveLength(3);
+    const configs = require('../getRollupConfig').default({ svelteConfig });
+    expect(configs).toHaveLength(2);
   });
 });

--- a/src/rollup/getRollupConfig.ts
+++ b/src/rollup/getRollupConfig.ts
@@ -136,27 +136,6 @@ export default function getRollupConfig(options) {
 
   const configs = [];
 
-  // Add ElderJs Peer deps to public if they exist.
-  [
-    ['./node_modules/intersection-observer/intersection-observer.js', './_elderjs/static/intersection-observer.js'],
-  ].forEach((dep) => {
-    if (!fs.existsSync(path.resolve(elderConfig.rootDir, dep[0]))) {
-      throw new Error(`Elder.js peer dependency not found at ${dep[0]}`);
-    }
-    const prefix = normalizePrefix(elderConfig.prefix);
-    configs.push({
-      input: dep[0],
-      output: [
-        {
-          file: path.resolve(prefix ? path.join(elderConfig.distDir, prefix) : elderConfig.distDir, dep[1]),
-          format: 'iife',
-          name: dep[1],
-          plugins: [terser()],
-        },
-      ],
-    });
-  });
-
   const { paths: pluginPaths } = getPluginLocations(elderConfig);
   const pluginGlobs = pluginPaths.map((plugin) => `${plugin}*.svelte`);
 

--- a/src/rollup/getRollupConfig.ts
+++ b/src/rollup/getRollupConfig.ts
@@ -6,14 +6,11 @@ import multiInput from 'rollup-plugin-multi-input';
 import replace from '@rollup/plugin-replace';
 import json from '@rollup/plugin-json';
 import glob from 'glob';
-import path from 'path';
-import fs from 'fs-extra';
 import defaultsDeep from 'lodash.defaultsdeep';
 import { getElderConfig } from '../index';
 import { getDefaultRollup } from '../utils/validations';
 import getPluginLocations from '../utils/getPluginLocations';
 import elderSvelte from './rollupPlugin';
-import normalizePrefix from '../utils/normalizePrefix';
 
 const production = process.env.NODE_ENV === 'production' || !process.env.ROLLUP_WATCH;
 


### PR DESCRIPTION
Currently two polyfills are added: *requestIdleCallback* and *IntersectionObserver*.  Both in an global and more importantly a blocking script tag.

*requestIdleCallback* is necessary, as there is weak safari support https://caniuse.com/requestidlecallback.
*IntersectionObserver* however is supported by basically every browser that also implements es6 modules which we need for loading the modules anyway. (Table at the bottom shows the combined map: https://caniuse.com/es6-module,intersectionobserver)

I'm suggesting two changes: 
1. Remove intersectionobserver as its a relatively large polyfill, the fallback is sensible, and removing it cleans up the rollup/esbuild code. For browsers that do not support it, we simply fall back to eager loading.
2. Move the requestIdleCallback polyfill to local scope.  We can move it to the script type=module tag which is non blocking, and we can use a much smaller polyfill as we never use the didTimeout and timeRemaining parameters returned. As a bonus this can be minified very well.

The primary change is in  src/partialHydration/hydrateComponents.ts , the other changes just remove the polyfill build dependencies, tests and references from the docs. I hope i got all of them.

