### PR TITLE
fix :bug: (linux) revert internal.distElder path for chokidar

### DIFF
--- a/src/rollup/rollupPlugin.ts
+++ b/src/rollup/rollupPlugin.ts
@@ -357,8 +357,7 @@ export const devServer = ({
         [
           path.resolve(process.cwd(), './src'),
           path.resolve(process.cwd(), './elder.config.js'),
-          `${elderConfig.$$internal.distElder}/assets`,
-          `${elderConfig.$$internal.distElder}/svelte`,
+          elderConfig.$$internal.distElder,
           path.join(elderConfig.$$internal.ssrComponents, 'components'),
           path.join(elderConfig.$$internal.ssrComponents, 'layouts'),
           path.join(elderConfig.$$internal.ssrComponents, 'routes'),


### PR DESCRIPTION
Revert a change made in chokidar watch regarding the internal.distElder path. 
Fixed #202, #198
I have to check for #196 
If they are no special reason for that change, I think it's safe to revert it.