### PR TITLE
docs: Include the name of the directory in the cd cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The quickest way to get started is to get started with the [Elder.js template](h
 ```sh
 npx degit Elderjs/template elderjs-app
 
-cd
+cd elderjs-app
 
 npm install # or "yarn"
 


### PR DESCRIPTION
`cd` by itself just changes into your home directory. I think a lot of people are going to copy and paste this, so it should work as code, not just a hint to "cd into the directory you created in the step above".

Plus, it makes it clear that `npx degit` is creating a directory.