### PR TITLE
Fix for rollup replace plugin warning

### DIFF
--- a/src/rollup/getRollupConfig.ts
+++ b/src/rollup/getRollupConfig.ts
@@ -26,6 +26,7 @@ export function createBrowserConfig({
   const toReplace = {
     'process.env.componentType': "'browser'",
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+    preventAssignment: true,
     ...replacements,
   };
 


### PR DESCRIPTION
https://github.com/sveltejs/sapper-template/issues/302
https://github.com/rollup/plugins/tree/master/packages/replace#preventassignment

```sh
Plugin replace: @rollup/plugin-replace: 'preventAssignment' currently defaults to false.
It is recommended to set this option to `true`, as the next major version will default this option to `true`.
```