### PR TITLE
fix esbuild if srcDir is different from the default

### DIFF
--- a/src/esbuild/esbuildBundler.ts
+++ b/src/esbuild/esbuildBundler.ts
@@ -97,7 +97,7 @@ const svelteHandler = async ({ elderConfig, svelteConfig, replacements, restartH
 
     // eslint-disable-next-line global-require
     const pkg = require(path.resolve(elderConfig.rootDir, './package.json'));
-    const globPath = path.resolve(elderConfig.rootDir, `./src/**/*.svelte`);
+    const globPath = path.resolve(elderConfig.rootDir, elderConfig.srcDir, `/**/*.svelte`);
     const initialEntryPoints = glob.sync(globPath);
     const sveltePackages = getPackagesWithSvelte(pkg, elderConfig);
     const elderPlugins = getPluginLocations(elderConfig);
@@ -161,7 +161,7 @@ const svelteHandler = async ({ elderConfig, svelteConfig, replacements, restartH
       splitting: true,
       chunkNames: 'chunks/[name].[hash]',
       logLevel: 'error',
-      outbase: 'src',
+      outbase: elderConfig.srcDir,
       define: {
         'process.env.componentType': "'browser'",
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),

--- a/src/partialHydration/__tests__/prepareFindSvelteComponent.spec.ts
+++ b/src/partialHydration/__tests__/prepareFindSvelteComponent.spec.ts
@@ -327,6 +327,7 @@ describe('#prepareFindSvelteComponent', () => {
     const common = {
       ssrFolder: path.resolve(`./test/___ELDER___/compiled`),
       rootDir: path.resolve(`./test/`),
+      srcDir: path.resolve('./test/src'),
       clientComponents: path.resolve(`./test/public/_elderjs/svelte/`),
       distDir: path.resolve(`./test/public`),
     };

--- a/src/partialHydration/prepareFindSvelteComponent.ts
+++ b/src/partialHydration/prepareFindSvelteComponent.ts
@@ -13,7 +13,7 @@ export const removeHash = (pathWithHash) => {
   return pathWithHash;
 };
 
-const prepareFindSvelteComponent = ({ ssrFolder, rootDir, clientComponents: clientFolder, distDir }) => {
+const prepareFindSvelteComponent = ({ ssrFolder, rootDir, srcDir, clientComponents: clientFolder, distDir }) => {
   const rootDirFixed = windowsPathFix(rootDir);
   const ssrComponents = glob.sync(`${ssrFolder}/**/*.js`).map(windowsPathFix);
   const clientComponents = glob
@@ -29,7 +29,7 @@ const prepareFindSvelteComponent = ({ ssrFolder, rootDir, clientComponents: clie
 
     // abs path first
     if (nameFixed.includes(rootDirFixed)) {
-      const rel = windowsPathFix(path.relative(path.join(rootDirFixed, 'src'), name))
+      const rel = windowsPathFix(path.relative(path.join(rootDirFixed, srcDir.replace(rootDir, '')), name))
         .replace('.svelte', '.js')
         .toLowerCase();
       const parsed = path.parse(rel);

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -51,6 +51,7 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
     findComponent: prepareFindSvelteComponent({
       ssrFolder: ssrComponents,
       rootDir,
+      srcDir: config.srcDir,
       clientComponents,
       distDir: config.distDir,
     }),


### PR DESCRIPTION
If the `srcDir` in the `elder.config.js` is set to something other than `src`, then esbuild no longer works correctly. This pull request aims to fix this.

Everything seems to work fine (including hydration) except that the `onMount` svelte hook isn't called for the demo clock component and I can't work out why.