### PR TITLE
feat: Configurable Request Cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elderjs/elderjs",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/routes/__tests__/prepareRouter.spec.ts
+++ b/src/routes/__tests__/prepareRouter.spec.ts
@@ -157,6 +157,22 @@ describe('#prepareRouter', () => {
       );
       expect(requestCache.has('/dev/reports/hereitis/')).toBeTruthy();
     });
+    it('Parses a dynamic route into a request properly and skips the cache', () => {
+      expect(
+        requestFromDynamicRoute({
+          req: { path: '/dev/reports/without-cache/' },
+          requestCache: undefined,
+          dynamicRoutes,
+        }),
+      ).toEqual({
+        permalink: '',
+        report: 'without-cache',
+        req: { path: '/dev/reports/without-cache/', query: undefined, search: undefined },
+        route: 'reports',
+        type: 'server',
+      });
+      expect(requestCache.has('/dev/reports/without-cache/')).toBeFalsy();
+    });
     it('correctly adds in different search and query params', () => {
       expect(
         requestFromDynamicRoute({

--- a/src/routes/prepareRouter.ts
+++ b/src/routes/prepareRouter.ts
@@ -82,7 +82,7 @@ export function requestFromDynamicRoute({
   dynamicRoutes,
   requestCache,
 }: IRequestFromDynamicRoute): RequestOptions | false {
-  if (requestCache?.has(req.path)) {
+  if (requestCache && requestCache.has(req.path)) {
     const request = requestCache.get(req.path);
     request.req = req;
     return request;
@@ -96,7 +96,9 @@ export function requestFromDynamicRoute({
       type: 'server',
       ...params,
     };
-    requestCache?.set(req.path, request);
+    if (requestCache) {
+      requestCache?.set(req.path, request);
+    }
     request.req = { ...req };
     return request;
   }

--- a/src/routes/prepareRouter.ts
+++ b/src/routes/prepareRouter.ts
@@ -97,7 +97,7 @@ export function requestFromDynamicRoute({
       ...params,
     };
     if (requestCache) {
-      requestCache?.set(req.path, request);
+      requestCache.set(req.path, request);
     }
     request.req = { ...req };
     return request;

--- a/src/routes/prepareRouter.ts
+++ b/src/routes/prepareRouter.ts
@@ -74,7 +74,7 @@ export const initialRequestIsWellFormed = (request: RequestOptions) =>
 interface IRequestFromDynamicRoute {
   req: Req;
   dynamicRoutes: RouteOptions[];
-  requestCache: Map<string, RequestOptions>;
+  requestCache: Map<string, RequestOptions> | undefined;
 }
 
 export function requestFromDynamicRoute({
@@ -82,7 +82,7 @@ export function requestFromDynamicRoute({
   dynamicRoutes,
   requestCache,
 }: IRequestFromDynamicRoute): RequestOptions | false {
-  if (requestCache.has(req.path)) {
+  if (requestCache?.has(req.path)) {
     const request = requestCache.get(req.path);
     request.req = req;
     return request;
@@ -96,7 +96,7 @@ export function requestFromDynamicRoute({
       type: 'server',
       ...params,
     };
-    requestCache.set(req.path, request);
+    requestCache?.set(req.path, request);
     request.req = { ...req };
     return request;
   }
@@ -105,7 +105,7 @@ export function requestFromDynamicRoute({
 
 function prepareRouter(Elder) {
   const { routes, serverLookupObject, settings, ...elder } = Elder;
-  const requestCache = new Map();
+  const requestCache = settings.server.cacheRequests ? new Map() : undefined;
 
   // sort the routes in order of specificity
   const dynamicRoutes: RouteOptions[] = routeSort(

--- a/src/utils/__tests__/__snapshots__/validations.spec.ts.snap
+++ b/src/utils/__tests__/__snapshots__/validations.spec.ts.snap
@@ -789,6 +789,7 @@ Object {
       "_exclusive": Object {},
       "_mutate": undefined,
       "_nodes": Array [
+        "cacheRequests",
         "prefix",
       ],
       "_options": Object {
@@ -802,6 +803,33 @@ Object {
         "refs": Map {},
       },
       "fields": Object {
+        "cacheRequests": Object {
+          "_blacklist": Object {
+            "list": Set {},
+            "refs": Map {},
+          },
+          "_conditions": Array [],
+          "_default": true,
+          "_deps": Array [],
+          "_exclusive": Object {},
+          "_label": "If Elder.js should cache requests when using dynamic routing.",
+          "_mutate": undefined,
+          "_options": Object {
+            "abortEarly": true,
+            "recursive": true,
+          },
+          "_type": "boolean",
+          "_typeError": [Function],
+          "_whitelist": Object {
+            "list": Set {},
+            "refs": Map {},
+          },
+          "tests": Array [],
+          "transforms": Array [
+            [Function],
+          ],
+          "type": "boolean",
+        },
         "prefix": Object {
           "_blacklist": Object {
             "list": Set {},

--- a/src/utils/__tests__/__snapshots__/validations.spec.ts.snap
+++ b/src/utils/__tests__/__snapshots__/validations.spec.ts.snap
@@ -812,7 +812,7 @@ Object {
           "_default": true,
           "_deps": Array [],
           "_exclusive": Object {},
-          "_label": "If Elder.js should cache requests when using dynamic routing.",
+          "_label": "If Elder.js should cache requests when using dynamic routing. It may be useful to turn off the cache when combining Elder.js with another caching solution to reduce the resources consumed by the server.",
           "_mutate": undefined,
           "_options": Object {
             "abortEarly": true,

--- a/src/utils/__tests__/validations.spec.ts
+++ b/src/utils/__tests__/validations.spec.ts
@@ -54,6 +54,7 @@ describe('#validations', () => {
     },
     server: {
       prefix: '',
+      cacheRequests: true,
     },
     shortcodes: {
       closePattern: '}}',

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,6 +5,7 @@ import Page from './Page';
 
 type ServerOptions = {
   prefix: string;
+  cacheRequests?: boolean;
 };
 
 type BuildOptions = {

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -102,7 +102,9 @@ const configSchema = yup.object({
       .boolean()
       .notRequired()
       .default(true)
-      .label(`If Elder.js should cache requests when using dynamic routing.`),
+      .label(
+        `If Elder.js should cache requests when using dynamic routing. It may be useful to turn off the cache when combining Elder.js with another caching solution.`,
+      ),
   }),
   prefix: yup
     .string()

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -98,6 +98,11 @@ const configSchema = yup.object({
       .notRequired()
       .default('')
       .label(`If Elder.js should serve all pages with a prefix. (deprecated)`),
+    cacheRequests: yup
+      .boolean()
+      .notRequired()
+      .default(true)
+      .label(`If Elder.js should cache requests when using dynamic routing.`),
   }),
   prefix: yup
     .string()

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -103,7 +103,7 @@ const configSchema = yup.object({
       .notRequired()
       .default(true)
       .label(
-        `If Elder.js should cache requests when using dynamic routing. It may be useful to turn off the cache when combining Elder.js with another caching solution.`,
+        `If Elder.js should cache requests when using dynamic routing. It may be useful to turn off the cache when combining Elder.js with another caching solution to reduce the resources consumed by the server.`,
       ),
   }),
   prefix: yup


### PR DESCRIPTION
When running dynamic routing combined with an edge cache, it does not make much sense to use the built-in request cache provided by ElderJS, especially not when the cache never expires, or when running on a server with limited resources. It results in a server that keeps increasing in memory until it dies.

The PR aims to provide a configurable solution to this problem, by letting users turn off the cache via a setting.