### PR TITLE
Don't use a leading / if no serverPrefix is given

### DIFF
--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -70,6 +70,7 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
         config.$$internal.publicCssFile = `_elderjs/assets/${cssFiles[0]}`;
       } else {
         config.$$internal.publicCssFile = `${serverPrefix}/_elderjs/assets/${cssFiles[0]}`;
+      }
     } else {
       console.error(`CSS file not found in ${assetPath}`);
     }

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -66,7 +66,10 @@ function getConfig(initializationOptions: InitializationOptions = {}): SettingsO
       );
     }
     if (cssFiles[0]) {
-      config.$$internal.publicCssFile = `${serverPrefix}/_elderjs/assets/${cssFiles[0]}`;
+      if (serverPrefix == '') {
+        config.$$internal.publicCssFile = `_elderjs/assets/${cssFiles[0]}`;
+      } else {
+        config.$$internal.publicCssFile = `${serverPrefix}/_elderjs/assets/${cssFiles[0]}`;
     } else {
       console.error(`CSS file not found in ${assetPath}`);
     }


### PR DESCRIPTION
For context, I'm using elderjs to deploy my site to a traditional server and Fleek, where the content is hosted on IPFS. Some IPFS gateways resolve IPNS through URLs such as `https://ipfs.io/ipns/<url>`, meaning if the CSS href is pointing to `/_elderjs/assets/svelte-ddfc11db.css` it attempts to read `https://ipfs.io/_elderjs/assets/svelte-ddfc11db.css`, which will fail. This just adds a check to see if serverPrefix is blank, in which case it does not use a leading /.