### PR TITLE
Increase ElderAddExternalHelpers priority

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -11,7 +11,7 @@ const hooks: Array<HookOptions> = [
     hook: 'bootstrap',
     name: 'elderAddExternalHelpers',
     description: 'Adds external helpers to helpers object',
-    priority: 1,
+    priority: 50,
     run: async ({ helpers, query, settings }) => {
       let additionalHelpers = {};
       try {


### PR DESCRIPTION
I suggest to increase the priority of the `elderAddExternalHelpers` hook registered on `bootstrap`. The "informal" hook contract mentions that the valid range of priority values is from 1 to 100. If the priority of the `elderAddExternalHelpers` is 1 (lowest) then there's no way to register another `bootstrap` hook that can meaningfully utilize `helpers`.

A workaround seems to be to simply ignore the informal spec and register a hook with priority `0`. This hook will have access to functionality implemented by `helpers`.

See also the section on hook specification in the ElderJS doc:
https://elderguide.com/tech/elderjs/#hook-specification