### PR TITLE
Fix: make file reloading handle file name changes

### DIFF
--- a/src/rollup/rollupPlugin.ts
+++ b/src/rollup/rollupPlugin.ts
@@ -357,11 +357,11 @@ export const devServer = ({
         [
           path.resolve(process.cwd(), './src'),
           path.resolve(process.cwd(), './elder.config.js'),
-          `${elderConfig.$$internal.distElder}/assets`,
-          `${elderConfig.$$internal.distElder}/svelte`,
-          path.join(elderConfig.$$internal.ssrComponents, 'components'),
-          path.join(elderConfig.$$internal.ssrComponents, 'layouts'),
-          path.join(elderConfig.$$internal.ssrComponents, 'routes'),
+          path.join(elderConfig.$$internal.distElder, 'assets', sep),
+          path.join(elderConfig.$$internal.distElder, 'svelte', sep),
+          path.join(elderConfig.$$internal.ssrComponents, 'components', sep),
+          path.join(elderConfig.$$internal.ssrComponents, 'layouts', sep),
+          path.join(elderConfig.$$internal.ssrComponents, 'routes', sep),
         ],
         {
           ignored: '*.svelte',


### PR DESCRIPTION
Since version 1.5.0, file reloads have not worked correctly if your files are being renamed, such as when using TailwindCSS 3 (or 2 with JIT). The reason for this seems to be a bug in [chokidar](https://github.com/paulmillr/chokidar), that doesn't correctly handle deleting and re-creating a folder that is being directly watched. I've opened two issues in their repo about it: [Issue #1207](https://github.com/paulmillr/chokidar/issues/1207) and [Issue #1208](https://github.com/paulmillr/chokidar/issues/1208).

Before version 1.5.0 this worked, because the entire `elderConfig.$$internal.distElder` folder was being watched. When a folder was removed ([which it seems to be in server restarts](https://github.com/Elderjs/elderjs/blob/master/src/rollup/rollupPlugin.ts#L437-L444)) and re-created, chokidar noticed it without problems. But in version 1.5.0, the `assets` and `svelte` folders are explicitly being watched, and not their parent directory. Due to the bugs above, they are thus no longer tracked after the first server restart that deletes the folders. [See v1.5.0 changes here.](https://github.com/Elderjs/elderjs/pull/191/files#diff-6c3b9ada3f5ff8aee40c5b12e880632c36edc5f000592cf34dcce44bf6686017L244-R355)

I found a workaround ([see comment here](https://github.com/paulmillr/chokidar/issues/1207#issuecomment-1053328178)) and it seems that it works if you add a trailing slash to the watches. And that is what I have changed in this PR.

For a working example, I forked the template and added TailwindCSS 3, and changed to this fixed version. It handles the CSS renaming and reloads as it should. The repo is found here: https://github.com/ChristofferKarlsson/elderjs-template-tailwind.


I have only tested this on my machine:
- OS: Arch Linux (5.16.3-arch1-1)
- Node version: v17.3.0