### PR TITLE
Feat/perf improvements

### DIFF
--- a/src/Elder.ts
+++ b/src/Elder.ts
@@ -82,7 +82,7 @@ class Elder {
     this.bootstrapComplete = new Promise((resolve) => {
       this.markBootstrapComplete = resolve;
     });
-    this.uid = 'bootstrap';
+    this.uid = 'startup';
 
     // merge the given config with the project and defaults;
     this.settings = getConfig(initializationOptions);

--- a/src/Elder.ts
+++ b/src/Elder.ts
@@ -36,6 +36,7 @@ import workerBuild from './workerBuild';
 import { inlineSvelteComponent } from './partialHydration/inlineSvelteComponent';
 import elderJsShortcodes from './shortcodes';
 import prepareRouter from './routes/prepareRouter';
+import perf, { displayPerfTimings, prefixPerf } from './utils/perf';
 
 class Elder {
   bootstrapComplete: Promise<any>;
@@ -70,6 +71,10 @@ class Elder {
 
   shortcodes: ShortcodeDefs;
 
+  perf: any;
+
+  uid: string;
+
   router: (any) => any;
 
   constructor(initializationOptions: InitializationOptions = {}) {
@@ -77,6 +82,7 @@ class Elder {
     this.bootstrapComplete = new Promise((resolve) => {
       this.markBootstrapComplete = resolve;
     });
+    this.uid = 'bootstrap';
 
     // merge the given config with the project and defaults;
     this.settings = getConfig(initializationOptions);
@@ -96,8 +102,13 @@ class Elder {
       this.server = prepareServer({ bootstrapComplete: this.bootstrapComplete });
     }
 
+    perf(this, true);
+
+    this.perf.start('startup');
+
     // plugins are run first as they have routes, hooks, and shortcodes.
     plugins(this).then(async ({ pluginRoutes, pluginHooks, pluginShortcodes }) => {
+      this.perf.start('startup.validations');
       /**
        * Finalize Routes
        * Add in user routes
@@ -203,6 +214,8 @@ class Elder {
         .map((shortcode) => validateShortcode(shortcode))
         .filter(Boolean as any as ExcludesFalse);
 
+      this.perf.end('startup.validations');
+
       /**
        *
        * Almost ready for customize hooks and bootstrap
@@ -243,16 +256,21 @@ class Elder {
         await this.runHook('bootstrap', this);
 
         // collect all of our requests
+        this.perf.start('startup.routes');
         await asyncForEach(Object.keys(this.routes), async (routeName) => {
+          this.perf.start(`startup.routes.${routeName}`);
           const route = this.routes[routeName];
           let allRequestsForRoute = [];
           if (typeof route.all === 'function') {
+            this.perf.start(`startup.routes.${routeName}`);
             allRequestsForRoute = await route.all({
               settings: createReadOnlyProxy(this.settings, 'settings', `${routeName} all function`),
               query: createReadOnlyProxy(this.query, 'query', `${routeName} all function`),
               helpers: createReadOnlyProxy(this.helpers, 'helpers', `${routeName} all function`),
               data: createReadOnlyProxy(this.data, 'data', `${routeName} all function`),
+              perf: prefixPerf(this.perf, `startup.routes.${routeName}.all`),
             });
+            this.perf.end(`startup.routes.${routeName}`);
           } else if (Array.isArray(route.all)) {
             allRequestsForRoute = route.all;
           }
@@ -270,10 +288,14 @@ class Elder {
             return out;
           }, []);
           this.allRequests = this.allRequests.concat(allRequestsForRoute);
+          this.perf.end(`startup.routes.${routeName}`);
         });
+
+        this.perf.end(`startup.routes`);
 
         await this.runHook('allRequests', this);
 
+        this.perf.start(`startup.setPermalinks`);
         await asyncForEach(this.allRequests, async (request) => {
           if (!this.routes[request.route] || !this.routes[request.route].permalink) {
             if (!request.route) {
@@ -303,6 +325,9 @@ class Elder {
             this.serverLookupObject[request.permalink] = request;
           }
         });
+        this.perf.end(`startup.setPermalinks`);
+
+        this.perf.start(`startup.validatePermalinks`);
 
         if (this.allRequests.length !== new Set(this.allRequests.map((r) => r.permalink)).size) {
           // useful error logging for when there are duplicate permalinks.
@@ -318,10 +343,26 @@ class Elder {
             }
           }
         }
+        this.perf.end(`startup.validatePermalinks`);
 
+        this.perf.start(`startup.prepareRouter`);
         this.router = prepareRouter(this);
+        this.perf.end(`startup.prepareRouter`);
 
         this.markBootstrapComplete(this);
+
+        this.perf.end('startup');
+        this.perf.stop();
+
+        const t = this.perf.timings.slice(-1)[0] && Math.round(this.perf.timings.slice(-1)[0].duration * 10) / 10;
+        if (t && t > 0) {
+          console.log(
+            `Elder.js Startup: ${t}ms. ${t > 5000 ? `For details set debug.performance: true in elder.config.js` : ''}`,
+          );
+          if (this.settings.debug.performance) {
+            displayPerfTimings([...this.perf.timings]);
+          }
+        }
       });
     });
   }

--- a/src/Elder.ts
+++ b/src/Elder.ts
@@ -36,7 +36,7 @@ import workerBuild from './workerBuild';
 import { inlineSvelteComponent } from './partialHydration/inlineSvelteComponent';
 import elderJsShortcodes from './shortcodes';
 import prepareRouter from './routes/prepareRouter';
-import perf, { displayPerfTimings, prefixPerf } from './utils/perf';
+import perf, { displayPerfTimings } from './utils/perf';
 
 class Elder {
   bootstrapComplete: Promise<any>;
@@ -268,7 +268,7 @@ class Elder {
               query: createReadOnlyProxy(this.query, 'query', `${routeName} all function`),
               helpers: createReadOnlyProxy(this.helpers, 'helpers', `${routeName} all function`),
               data: createReadOnlyProxy(this.data, 'data', `${routeName} all function`),
-              perf: prefixPerf(this.perf, `startup.routes.${routeName}.all`),
+              perf: this.perf.prefix(`startup.routes.${routeName}.all`),
             });
             this.perf.end(`startup.routes.${routeName}`);
           } else if (Array.isArray(route.all)) {

--- a/src/__tests__/Elder.spec.ts
+++ b/src/__tests__/Elder.spec.ts
@@ -58,7 +58,7 @@ describe('#Elder', () => {
           for (const pluginHook of page.hooks) {
             if (pluginHook.$$meta.type === 'plugin') {
               // eslint-disable-next-line
-            await pluginHook.run({});
+              await pluginHook.run({});
             }
           }
         }
@@ -111,6 +111,7 @@ describe('#Elder', () => {
     const elder = await new Elder({ context: 'server', worker: false });
     await elder.bootstrap();
     await elder.worker([]);
+    delete elder.perf.timings;
     expect(normalizeSnapshot(elder)).toMatchSnapshot();
   });
 
@@ -200,6 +201,8 @@ describe('#Elder', () => {
     const { Elder } = require(`..${sep}index`);
     const elder = await new Elder({ context: 'server', worker: false });
     await elder.bootstrap();
+
+    delete elder.perf.timings;
     expect(normalizeSnapshot(elder)).toMatchSnapshot();
   });
 });

--- a/src/__tests__/__snapshots__/Elder.spec.ts.snap
+++ b/src/__tests__/__snapshots__/Elder.spec.ts.snap
@@ -27,6 +27,7 @@ Object {
         "errors",
       ],
       "props": Array [
+        "perf",
         "hookInterface",
         "errors",
       ],
@@ -47,6 +48,7 @@ Object {
         "query",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -72,6 +74,7 @@ Object {
         "allRequests",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -107,6 +110,7 @@ Object {
         "serverLookupObject",
       ],
       "props": Array [
+        "perf",
         "errors",
         "query",
         "helpers",
@@ -147,6 +151,7 @@ Object {
         "route",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -183,6 +188,7 @@ Object {
         "footerStack",
       ],
       "props": Array [
+        "perf",
         "data",
         "request",
         "errors",
@@ -224,6 +230,7 @@ Object {
         "customJsStack",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -258,6 +265,7 @@ Object {
         "footerStack",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -296,6 +304,7 @@ Object {
         "headString",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -318,6 +327,7 @@ Object {
         "htmlString",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -342,6 +352,7 @@ Object {
         "htmlString",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -367,6 +378,7 @@ Object {
         "errors",
       ],
       "props": Array [
+        "perf",
         "request",
         "htmlString",
         "query",
@@ -392,6 +404,7 @@ Object {
       "location": "Page.ts, build.ts",
       "mutable": Array [],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -409,6 +422,7 @@ Object {
       "location": "build.ts",
       "mutable": Array [],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -558,6 +572,12 @@ Object {
     },
   ],
   "markBootstrapComplete": [Function],
+  "perf": Object {
+    "end": [Function],
+    "prefix": [Function],
+    "start": [Function],
+    "stop": [Function],
+  },
   "query": Object {},
   "router": [Function],
   "routes": Object {
@@ -632,6 +652,7 @@ Object {
       "shortcode": "svelteComponent",
     },
   ],
+  "uid": "startup",
 }
 `;
 
@@ -669,6 +690,7 @@ Object {
         "errors",
       ],
       "props": Array [
+        "perf",
         "hookInterface",
         "errors",
       ],
@@ -689,6 +711,7 @@ Object {
         "query",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -714,6 +737,7 @@ Object {
         "allRequests",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -749,6 +773,7 @@ Object {
         "serverLookupObject",
       ],
       "props": Array [
+        "perf",
         "errors",
         "query",
         "helpers",
@@ -789,6 +814,7 @@ Object {
         "route",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -825,6 +851,7 @@ Object {
         "footerStack",
       ],
       "props": Array [
+        "perf",
         "data",
         "request",
         "errors",
@@ -866,6 +893,7 @@ Object {
         "customJsStack",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -900,6 +928,7 @@ Object {
         "footerStack",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -938,6 +967,7 @@ Object {
         "headString",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -960,6 +990,7 @@ Object {
         "htmlString",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -984,6 +1015,7 @@ Object {
         "htmlString",
       ],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -1009,6 +1041,7 @@ Object {
         "errors",
       ],
       "props": Array [
+        "perf",
         "request",
         "htmlString",
         "query",
@@ -1034,6 +1067,7 @@ Object {
       "location": "Page.ts, build.ts",
       "mutable": Array [],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -1051,6 +1085,7 @@ Object {
       "location": "build.ts",
       "mutable": Array [],
       "props": Array [
+        "perf",
         "helpers",
         "data",
         "settings",
@@ -1210,6 +1245,12 @@ Object {
     },
   ],
   "markBootstrapComplete": [Function],
+  "perf": Object {
+    "end": [Function],
+    "prefix": [Function],
+    "start": [Function],
+    "stop": [Function],
+  },
   "query": Object {},
   "router": [Function],
   "routes": Object {
@@ -1291,5 +1332,6 @@ Object {
       "shortcode": "svelteComponent",
     },
   ],
+  "uid": "startup",
 }
 `;

--- a/src/hooks/hookEntityDefinitions.ts
+++ b/src/hooks/hookEntityDefinitions.ts
@@ -46,6 +46,7 @@ const hookEntityDefinitions = {
     "The compiled HTML response for a route containing all of the HTML from the Route's layout and template. ",
   serverLookupObject: `A key value object where the key is the relative permalink and the object is the 'request' object used by the Elder.js server.`,
   runHook: `The function that powers hooks. 'await runhook('hookName', objectContainingProps)`,
+  perf: `Includes two functions: perf.start('thingToTrack') and perf.end('thingToTrack') which allows easily adding tracking to Elder.js' perf reporting which can be toggled under debug.performance in your elder.config.js file.`,
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/hooks/hookInterface.ts
+++ b/src/hooks/hookInterface.ts
@@ -6,7 +6,7 @@ import type { HookInterface } from './types';
 export const hookInterface: Array<HookInterface> = [
   {
     hook: 'customizeHooks',
-    props: ['hookInterface', 'errors'],
+    props: ['perf', 'hookInterface', 'errors'],
     mutable: ['hookInterface', 'errors'],
     context: 'Used to modify what hooks can mutate which properties all hooks.',
     use: `<p>This hook receives the hookInterface.ts file which defines all hook interactions. You can customize all 'props' and 'mutable' of
@@ -17,7 +17,7 @@ export const hookInterface: Array<HookInterface> = [
   },
   {
     hook: 'bootstrap',
-    props: ['helpers', 'data', 'settings', 'routes', 'hooks', 'query', 'errors'],
+    props: ['perf', 'helpers', 'data', 'settings', 'routes', 'hooks', 'query', 'errors'],
     mutable: ['errors', 'helpers', 'data', 'settings', 'query'],
     context: 'Routes, plugins, and hooks have been collected and validated.',
     use: `<ul>
@@ -31,7 +31,7 @@ export const hookInterface: Array<HookInterface> = [
   },
   {
     hook: 'allRequests',
-    props: ['helpers', 'data', 'settings', 'allRequests', 'routes', 'query', 'errors'],
+    props: ['perf', 'helpers', 'data', 'settings', 'allRequests', 'routes', 'query', 'errors'],
     mutable: ['errors', 'allRequests'],
     context: `allRequests which represents all of the request objects have been collected from route and plugins. This makes the 'allRequests' array mutable.`,
     use: `<p>The main use here is to allow users to adjust the requests that Elder.js is aware of.</p><ul>
@@ -49,6 +49,7 @@ export const hookInterface: Array<HookInterface> = [
   {
     hook: 'middleware',
     props: [
+      'perf',
       'errors',
       'query',
       'helpers',
@@ -96,7 +97,7 @@ export const hookInterface: Array<HookInterface> = [
 
   {
     hook: 'request',
-    props: ['helpers', 'data', 'settings', 'request', 'allRequests', 'query', 'errors', 'routes', 'route'],
+    props: ['perf', 'helpers', 'data', 'settings', 'request', 'allRequests', 'query', 'errors', 'routes', 'route'],
     mutable: ['errors', 'helpers', 'data', 'settings', 'request', 'route'],
     context: `This is executed at the beginning the request object being processed.`,
     use: `<p>This hook gives access to the entire state of a request lifecycle before it starts.</p>
@@ -115,6 +116,7 @@ export const hookInterface: Array<HookInterface> = [
   {
     hook: 'data',
     props: [
+      'perf',
       'data',
       'request',
       'errors',
@@ -160,6 +162,7 @@ export const hookInterface: Array<HookInterface> = [
   {
     hook: 'shortcodes',
     props: [
+      'perf',
       'helpers',
       'data',
       'settings',
@@ -185,6 +188,7 @@ export const hookInterface: Array<HookInterface> = [
   {
     hook: 'stacks',
     props: [
+      'perf',
       'helpers',
       'data',
       'settings',
@@ -230,7 +234,7 @@ export const hookInterface: Array<HookInterface> = [
 
   {
     hook: 'head',
-    props: ['helpers', 'data', 'settings', 'request', 'headString', 'query', 'errors'],
+    props: ['perf', 'helpers', 'data', 'settings', 'request', 'headString', 'query', 'errors'],
     mutable: ['errors', 'headString'],
     context: 'Executed just before writing the <head> tag to the page.',
     use: `<p>This hook's headSting represents everything that will be written to &lt;head&gt; tag.</p>
@@ -243,6 +247,7 @@ export const hookInterface: Array<HookInterface> = [
   {
     hook: 'compileHtml',
     props: [
+      'perf',
       'helpers',
       'data',
       'settings',
@@ -264,7 +269,7 @@ export const hookInterface: Array<HookInterface> = [
 
   {
     hook: 'html',
-    props: ['helpers', 'data', 'settings', 'request', 'htmlString', 'query', 'errors'],
+    props: ['perf', 'helpers', 'data', 'settings', 'request', 'htmlString', 'query', 'errors'],
     mutable: ['errors', 'htmlString'],
     context: 'Executed when all of the html has been compiled.',
     use: `<p>This hook receives the full html of the document. With great power comes great responsibility.</p>
@@ -280,7 +285,7 @@ export const hookInterface: Array<HookInterface> = [
 
   {
     hook: 'requestComplete',
-    props: ['request', 'htmlString', 'query', 'settings', 'errors', 'timings', 'data'],
+    props: ['perf', 'request', 'htmlString', 'query', 'settings', 'errors', 'timings', 'data'],
     mutable: ['errors'],
     context: 'This hook marks the end of the request lifecycle.',
     use: `<p>This hook is triggered on an individual 'request object' completing whether Elder.js is being used in the "build" or a "server" mode.</p>
@@ -297,7 +302,7 @@ export const hookInterface: Array<HookInterface> = [
   },
   {
     hook: 'error',
-    props: ['helpers', 'data', 'settings', 'request', 'query', 'errors'],
+    props: ['perf', 'helpers', 'data', 'settings', 'request', 'query', 'errors'],
     mutable: [],
     context: 'Executed only if the script has encountered errors and they are pushed to the errors array.',
     use: `<p>As the script encounters errors, they are collected and presented on this hook at the end of a request and the end of an entire build.</p>`,
@@ -308,7 +313,7 @@ export const hookInterface: Array<HookInterface> = [
 
   {
     hook: 'buildComplete',
-    props: ['helpers', 'data', 'settings', 'timings', 'query', 'errors', 'routes', 'allRequests'],
+    props: ['perf', 'helpers', 'data', 'settings', 'timings', 'query', 'errors', 'routes', 'allRequests'],
     mutable: [],
     context: 'Executed after a build is complete',
     use: `<p>Contains whether the build was successful. If not it contains errors for the entire build. Also includes

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,6 +5,7 @@ import { parseBuildPerf } from '../utils';
 import externalHelpers from '../externalHelpers';
 import { HookOptions } from './types';
 import prepareShortcodeParser from '../utils/prepareShortcodeParser';
+import { displayPerfTimings } from '../utils/perf';
 
 const hooks: Array<HookOptions> = [
   {
@@ -212,10 +213,7 @@ const hooks: Array<HookOptions> = [
       if (!settings.build && process.env.NODE_ENV !== 'production') {
         if (settings.debug.performance) {
           console.log(`${Math.round(timings.slice(-1)[0].duration * 10) / 10}ms: \t ${request.permalink}`);
-          const outTimings = [...timings];
-          const display = outTimings.sort((a, b) => a.duration - b.duration).map((t) => ({ ...t, ms: t.duration }));
-
-          console.table(display, ['name', 'ms']);
+          displayPerfTimings([...timings]);
         } else {
           console.log(request.permalink);
         }

--- a/src/plugins/__tests__/plugins.spec.ts
+++ b/src/plugins/__tests__/plugins.spec.ts
@@ -2,6 +2,11 @@ import path from 'path';
 
 const findComponent = () => ({ ssr: true, client: true, iife: undefined });
 
+const perf = {
+  start: () => {},
+  end: () => {},
+};
+
 describe('#plugins', () => {
   beforeEach(() => jest.resetModules());
 
@@ -31,6 +36,7 @@ describe('#plugins', () => {
     // eslint-disable-next-line global-require
     const plugins = require('../index').default;
     const { pluginRoutes, pluginHooks, pluginShortcodes } = await plugins({
+      perf,
       settings: {
         plugins: {},
         srcDir: 'test/src',
@@ -51,6 +57,7 @@ describe('#plugins', () => {
     // eslint-disable-next-line global-require
     const plugins = require('../index').default;
     const { pluginRoutes, pluginHooks, pluginShortcodes } = await plugins({
+      perf,
       settings: {
         plugins: {
           'elder-plugin-upload-s3': {
@@ -86,6 +93,7 @@ describe('#plugins', () => {
     // eslint-disable-next-line global-require
     const plugins = require('../index').default;
     const { pluginRoutes, pluginHooks, pluginShortcodes } = await plugins({
+      perf,
       settings: {
         plugins: {
           'elder-plugin-upload-s3': {
@@ -142,6 +150,7 @@ describe('#plugins', () => {
     // eslint-disable-next-line global-require
     const plugins = require('../index').default;
     const { pluginRoutes, pluginHooks, pluginShortcodes } = await plugins({
+      perf,
       settings: {
         plugins: {
           'elder-plugin-upload-s3': {
@@ -214,6 +223,7 @@ describe('#plugins', () => {
     // eslint-disable-next-line global-require
     const plugins = require('../index').default;
     const { pluginRoutes, pluginHooks, pluginShortcodes } = await plugins({
+      perf,
       settings: {
         plugins: {
           'elder-plugin-upload-s3': {

--- a/src/utils/Page.ts
+++ b/src/utils/Page.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 import getUniqueId from './getUniqueId';
-import perf, { prefixPerf } from './perf';
+import perf from './perf';
 import prepareProcessStack from './prepareProcessStack';
 import { ShortcodeDefs } from '../shortcodes/types';
 import { QueryOptions, Stack, RequestOptions, SettingsOptions, HydrateOptions } from './types';
@@ -27,7 +27,7 @@ const buildPage = async (page) => {
         settings: createReadOnlyProxy(page.settings, 'settings', `${page.request.route}: data function`),
         request: createReadOnlyProxy(page.request, 'request', `${page.request.route}: data function`),
         errors: page.errors,
-        perf: prefixPerf(page.perf, 'data'),
+        perf: page.perf.prefix('data'),
         allRequests: createReadOnlyProxy(page.allRequests, 'allRequests', `${page.request.route}: data function`),
         next: page.next,
       });

--- a/src/utils/Page.ts
+++ b/src/utils/Page.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 import getUniqueId from './getUniqueId';
-import perf from './perf';
+import perf, { prefixPerf } from './perf';
 import prepareProcessStack from './prepareProcessStack';
 import { ShortcodeDefs } from '../shortcodes/types';
 import { QueryOptions, Stack, RequestOptions, SettingsOptions, HydrateOptions } from './types';
@@ -27,7 +27,7 @@ const buildPage = async (page) => {
         settings: createReadOnlyProxy(page.settings, 'settings', `${page.request.route}: data function`),
         request: createReadOnlyProxy(page.request, 'request', `${page.request.route}: data function`),
         errors: page.errors,
-        perf: page.perf,
+        perf: prefixPerf(page.perf, 'data'),
         allRequests: createReadOnlyProxy(page.allRequests, 'allRequests', `${page.request.route}: data function`),
         next: page.next,
       });

--- a/src/utils/__tests__/Page.spec.ts
+++ b/src/utils/__tests__/Page.spec.ts
@@ -29,6 +29,7 @@ jest.mock('../perf', () => (page) => {
     start: jest.fn(),
     end: jest.fn(),
     stop: jest.fn(),
+    prefix: jest.fn(),
   };
 });
 
@@ -208,6 +209,10 @@ describe('#Page', () => {
     errors: [],
     runHook,
     shortcodes: [],
+    perf: {
+      start: () => {},
+      stop: () => {},
+    },
   };
 
   it('initialize and build', async () => {

--- a/src/utils/__tests__/__snapshots__/Page.spec.ts.snap
+++ b/src/utils/__tests__/__snapshots__/Page.spec.ts.snap
@@ -62,6 +62,7 @@ Object {
         },
       ],
     },
+    "prefix": [MockFunction],
     "start": [MockFunction] {
       "calls": Array [
         Array [
@@ -339,6 +340,19 @@ Object {
         },
       ],
     },
+    "prefix": [MockFunction] {
+      "calls": Array [
+        Array [
+          "data",
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    },
     "start": [MockFunction] {
       "calls": Array [
         Array [
@@ -554,6 +568,19 @@ Object {
                       "type": "return",
                       "value": undefined,
                     },
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "prefix": [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      "data",
+                    ],
+                  ],
+                  "results": Array [
                     Object {
                       "type": "return",
                       "value": undefined,
@@ -1045,6 +1072,19 @@ Object {
                       "type": "return",
                       "value": undefined,
                     },
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "prefix": [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      "data",
+                    ],
+                  ],
+                  "results": Array [
                     Object {
                       "type": "return",
                       "value": undefined,

--- a/src/utils/__tests__/__snapshots__/perf.spec.ts.snap
+++ b/src/utils/__tests__/__snapshots__/perf.spec.ts.snap
@@ -1,10 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#perf works in performance 1`] = `
+exports[`#perf works in performance and mocks 1`] = `
 Object {
   "htmlString": "",
   "perf": Object {
     "end": [Function],
+    "prefix": [Function],
     "start": [Function],
     "stop": [Function],
     "timings": Array [

--- a/src/utils/__tests__/perf.spec.ts
+++ b/src/utils/__tests__/perf.spec.ts
@@ -17,7 +17,7 @@ class PerformanceObserverMock {
 }
 
 describe('#perf', () => {
-  it('works in performance', () => {
+  it('works in performance and mocks', () => {
     function MockPage() {
       this.uid = 'xxxxxxxx';
       this.htmlString = '';
@@ -45,6 +45,12 @@ describe('#perf', () => {
 
     mockPage.perf.start('test');
     mockPage.perf.end('test');
+
+    const prefixed = mockPage.perf.prefix('prefix');
+
+    prefixed.start('prefix');
+    prefixed.end('prefix');
+
     mockPage.perf.stop();
 
     expect(normalizeSnapshot(mockPage)).toMatchSnapshot();
@@ -53,8 +59,12 @@ describe('#perf', () => {
       'mark test-start-xxxxxxxx',
       'mark test-end-xxxxxxxx',
       'measure test-xxxxxxxx',
+      'mark prefix.prefix-start-xxxxxxxx',
+      'mark prefix.prefix-end-xxxxxxxx',
+      'measure prefix.prefix-xxxxxxxx',
     ]);
   });
+
   it('works in non performance', () => {
     function MockPage() {
       this.uid = 'xxxxxxxx';

--- a/src/utils/__tests__/prepareRunHook.spec.ts
+++ b/src/utils/__tests__/prepareRunHook.spec.ts
@@ -58,7 +58,7 @@ describe('#prepareRunHook', () => {
     },
     magicNumber: 42,
   };
-  const perf = { start: jest.fn(), end: jest.fn() };
+  const perf = { start: jest.fn(), end: jest.fn(), prefix: () => {} };
   let prepareRunHookFn = prepareRunHook({ hooks: [hooks[0], hooks[1]], allSupportedHooks, settings });
 
   it('throws for unknown hook', async () => {

--- a/src/utils/perf.ts
+++ b/src/utils/perf.ts
@@ -1,4 +1,5 @@
 import { performance, PerformanceObserver } from 'perf_hooks';
+import { Elder } from '..';
 import Page from './Page';
 /**
  * A little helper around perf_hooks.
@@ -7,8 +8,13 @@ import Page from './Page';
  * This allows you to pass in a page.perf.start('name') and then page.perf.end('name') and the result is stored in a timings array.
  *
  */
-const perf = (page: Page) => {
-  if (page.settings.debug.performance) {
+
+export type TPerfTiming = { name: string; duration: number };
+
+export type TPerfTimings = TPerfTiming[];
+
+const perf = (page: Page | Elder, force = false) => {
+  if (page.settings.debug.performance || force) {
     let obs = new PerformanceObserver((items) => {
       items.getEntries().forEach((entry) => {
         if (entry.name.includes(page.uid)) {
@@ -58,3 +64,12 @@ const perf = (page: Page) => {
 };
 
 export default perf;
+
+export const displayPerfTimings = (timings: TPerfTimings) => {
+  const display = timings.sort((a, b) => a.duration - b.duration).map((t) => ({ ...t, ms: t.duration }));
+  console.table(display, ['name', 'ms']);
+};
+
+export const prefixPerf = (perfObj, prefix) => {
+  return { start: (name) => perfObj.start(`${prefix}.${name}`), end: (name) => perfObj.end(`${prefix}.${name}`) };
+};

--- a/src/utils/perf.ts
+++ b/src/utils/perf.ts
@@ -33,6 +33,7 @@ const perf = (page: Page | Elder, force = false) => {
        * @param {String} label
        */
       start: (label: string) => {
+        console.log(`${label}-start-${page.uid}`);
         performance.mark(`${label}-start-${page.uid}`);
       },
       /**
@@ -61,6 +62,12 @@ const perf = (page: Page | Elder, force = false) => {
       stop: placeholder,
     };
   }
+
+  // eslint-disable-next-line no-param-reassign
+  page.perf.prefix = (pre) => {
+    console.log('prefix', pre);
+    return { start: (name) => page.perf.start(`${pre}.${name}`), end: (name) => page.perf.end(`${pre}.${name}`) };
+  };
 };
 
 export default perf;
@@ -68,8 +75,4 @@ export default perf;
 export const displayPerfTimings = (timings: TPerfTimings) => {
   const display = timings.sort((a, b) => a.duration - b.duration).map((t) => ({ ...t, ms: t.duration }));
   console.table(display, ['name', 'ms']);
-};
-
-export const prefixPerf = (perfObj, prefix) => {
-  return { start: (name) => perfObj.start(`${prefix}.${name}`), end: (name) => perfObj.end(`${prefix}.${name}`) };
 };

--- a/src/utils/prepareRunHook.ts
+++ b/src/utils/prepareRunHook.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-param-reassign */
 import createReadOnlyProxy from './createReadOnlyProxy';
-import { prefixPerf } from './perf';
 
 // TODO: How do we get types to the user when they are writing plugins, etc?
 function prepareRunHook({ hooks, allSupportedHooks, settings }) {
@@ -17,7 +16,7 @@ function prepareRunHook({ hooks, allSupportedHooks, settings }) {
       if (cv === 'perf') return out; // perf added and  prefixed below
 
       if (Object.hasOwnProperty.call(props, cv)) {
-        if (!hookDefinition.mutable.includes(cv)) {
+        if (!hookDefinition.mutable.includes(cv) && cv !== 'perf') {
           out[cv] = createReadOnlyProxy(props[cv], cv, hookName);
         } else {
           out[cv] = props[cv];
@@ -49,7 +48,7 @@ function prepareRunHook({ hooks, allSupportedHooks, settings }) {
           try {
             let hookResponse = await hook.run({
               ...hookProps,
-              perf: prefixPerf(props.perf, `hook.${hookName}.${hook.name}`),
+              perf: props.perf.prefix(`hook.${hookName}.${hook.name}`),
             });
 
             if (!hookResponse) hookResponse = {};

--- a/src/utils/prepareServer.ts
+++ b/src/utils/prepareServer.ts
@@ -1,7 +1,8 @@
 function prepareServer({ bootstrapComplete }) {
   // eslint-disable-next-line consistent-return
   return async function prepServer(req, res, next) {
-    const { runHook, ...bootstrap } = await bootstrapComplete;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { runHook, perf, ...bootstrap } = await bootstrapComplete;
 
     await runHook('middleware', {
       ...bootstrap,


### PR DESCRIPTION
On findenergy.com we were troubleshooting some slow loading dev reloads. Instead of a bunch of console.logs I've now extended Elder.js' perf functionality to the startup process, all hooks, plugins, data functions and all functions.

In each of these areas you can use `perf.start('foo')` and `perf.end('foo')` while you have `debug.performance: true` in your `elder.config.js` and you'll get a pretty fully traceable printout of what is slowing things down.