### PR TITLE
Fixed esbuild plugin to work with svelte.config.[js,mjs,cjs]

### DIFF
--- a/src/esbuild/esbuildBundler.ts
+++ b/src/esbuild/esbuildBundler.ts
@@ -23,17 +23,30 @@ export type TSvelteHandler = {
 };
 
 export async function getSvelteConfig(elderConfig: SettingsOptions): Promise<TPreprocess> {
-  const svelteConfigPath = path.resolve(elderConfig.rootDir, `./svelte.config.js`);
-  if (fs.existsSync(svelteConfigPath)) {
+	const svelteConfigFileExts = ['js', 'cjs', 'mjs'];
+	let svelteConfigPath = '';
+	let svelteConfigFileExt = '';
+	for (const extension of svelteConfigFileExts) {
+		const filePath = path.resolve(elderConfig.rootDir, `./svelte.config.${extension}`);
+		if (fs.existsSync(filePath)) {
+			svelteConfigFileExt = extension;
+			svelteConfigPath = filePath;
+			break;	
+		}
+	}
+
+  if (svelteConfigPath) {
     try {
       const req = await import(svelteConfigPath);
       if (req) {
-        return req;
+        return req.default;
       }
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
-        console.warn(`Unable to load svelte.config.js from ${svelteConfigPath}`, err);
-      }
+        console.warn(`Unable to load svelte.config.${svelteConfigFileExt} from ${svelteConfigPath}`, err);
+      } else {
+				console.error(`Error in svelte.config.${svelteConfigFileExt}`, err);
+			}
       return false;
     }
   }


### PR DESCRIPTION
1. Added checking for svelte config file with .js, .mjs, and .cjs file extensions.
2. Adjusted the imported variable to return the ```default``` value (ESM import).
3. Adjusted try catch to not swallow errors in the svelte.config.[js,mjs,cjs] file.