### PR TITLE
Adjusted propCompression key to never be NaN

### DIFF
--- a/src/partialHydration/propCompression.ts
+++ b/src/partialHydration/propCompression.ts
@@ -58,6 +58,9 @@ export const getName = (num: number, counts: Map<string, number>, replacementCha
     // eslint-disable-next-line no-bitwise
     num = ~~(num / length) - 1;
   } while (num >= 0);
+	
+	// make sure prop key can't be NaN
+	if (name === 'NaN') name = 'Na_N';
 
   if (counts.has(name)) name = `${name}_`;
 


### PR DESCRIPTION
Added a check in the prop compression getName function that sets a prop key that would be NaN to Na_N.